### PR TITLE
fix(deploy): --changed-only noop no longer archives all pages

### DIFF
--- a/src/ccfm_convert/main.py
+++ b/src/ccfm_convert/main.py
@@ -159,6 +159,11 @@ def main():
         print("Error: Specify either --file or --directory")
         sys.exit(1)
 
+    # Snapshot all current on-disk files before any --changed-only filtering.
+    # Used for accurate orphan detection: orphans are files in state with no
+    # corresponding file on disk, not files excluded by --changed-only.
+    all_files = list(target_files)
+
     # ------------------------------------------------------------------
     # 5. Plan mode — show diff and exit
     # ------------------------------------------------------------------
@@ -178,6 +183,9 @@ def main():
     if args.changed_only:
         target_files = [f for f in target_files if state.has_changed(_rel_path(f), f)]
         print(f"ℹ️  --changed-only: {len(target_files)} file(s) with changes")
+        if not target_files:
+            print("ℹ️  No changes to deploy.")
+            return
 
     # ------------------------------------------------------------------
     # 7. Dump mode — write ADF locally, no API calls
@@ -232,7 +240,7 @@ def main():
     # 9. Archive orphaned pages
     # ------------------------------------------------------------------
     if args.archive_orphans:
-        orphans = state.find_orphans(target_files, args.docs_root)
+        orphans = state.find_orphans(all_files, args.docs_root)
         if orphans:
             print(f"\n🗄️  Archiving {len(orphans)} orphaned page(s)...")
             for rel_path in orphans:

--- a/tests/smoke/test_state_management.py
+++ b/tests/smoke/test_state_management.py
@@ -97,6 +97,100 @@ class TestChangedOnly:
             PAGE_ALPHA.write_text(original_content, encoding="utf-8")
 
 
+class TestChangedOnlyWithArchiveOrphans:
+    """Regression tests for issue #3.
+
+    When --changed-only detects 0 changes, the deploy must be a no-op — no pages
+    should be updated and no pages should be archived.  Previously the tool would
+    traverse the full tree despite 0 changes, then archive every page because the
+    orphan check compared state against an empty visited set.
+    """
+
+    def test_noop_run_does_not_archive_any_pages(self, ccfm_run, confluence_live):
+        """Second deploy with --changed-only --archive-orphans must not archive anything.
+
+        Reproduces issue #3: run --changed-only --archive-orphans when no files
+        have changed since the previous deploy. All pages must remain deployed.
+        """
+        # Step 1: clean deploy — ensures both pages exist in Confluence and state
+        result = ccfm_run("--directory", str(STATE_DIR))
+        assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
+
+        data_before = json.loads(SMOKE_STATE.read_text())
+        pages_before = set(data_before["pages"].keys())
+        assert pages_before, "State is empty after initial deploy"
+
+        # Step 2: re-run with both flags — no files have changed, must be a no-op
+        result = ccfm_run(
+            "--changed-only",
+            "--archive-orphans",
+            "--directory",
+            str(STATE_DIR),
+            check=False,
+        )
+
+        assert result.returncode == 0, f"--changed-only --archive-orphans failed:\n{result.stderr}"
+        assert (
+            "No changes to deploy" in result.stdout
+        ), f"Expected early-exit message when 0 changes detected.\nstdout: {result.stdout}"
+
+        # All pages tracked before must still be in state
+        data_after = json.loads(SMOKE_STATE.read_text())
+        pages_after = set(data_after["pages"].keys())
+        archived = pages_before - pages_after
+        assert not archived, (
+            f"Pages were incorrectly archived during a no-op run: {archived}\n"
+            f"stdout: {result.stdout}"
+        )
+
+    def test_unchanged_files_not_treated_as_orphans(self, ccfm_run, confluence_live):
+        """When only one file changes, unchanged files on disk must not be archived.
+
+        Reproduces issue #3 (Bug 2): orphan detection must use all current disk
+        files, not just the --changed-only subset.
+        """
+        # Step 1: clean baseline deploy
+        result = ccfm_run("--directory", str(STATE_DIR))
+        assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
+
+        data_before = json.loads(SMOKE_STATE.read_text())
+        beta_entries = [k for k in data_before["pages"] if BETA_KEY in k]
+        assert beta_entries, "page-beta not in state after deploy"
+
+        # Step 2: modify page-alpha only → --changed-only will deploy it, but
+        # page-beta is unchanged on disk and must not be treated as an orphan
+        original_content = PAGE_ALPHA.read_text(encoding="utf-8")
+        modified_content = original_content.replace(
+            "Version: **1**",
+            "Version: **3** — orphan regression test",
+        )
+        try:
+            PAGE_ALPHA.write_text(modified_content, encoding="utf-8")
+
+            result = ccfm_run(
+                "--changed-only",
+                "--archive-orphans",
+                "--directory",
+                str(STATE_DIR),
+                check=False,
+            )
+
+            assert (
+                result.returncode == 0
+            ), f"--changed-only --archive-orphans failed:\n{result.stderr}"
+
+            # page-beta must still be in state — it's on disk, not an orphan
+            data_after = json.loads(SMOKE_STATE.read_text())
+            beta_still_present = [k for k in data_after["pages"] if BETA_KEY in k]
+            assert beta_still_present, (
+                f"page-beta was incorrectly archived as an orphan.\n"
+                f"State after: {list(data_after['pages'].keys())}\n"
+                f"stdout: {result.stdout}"
+            )
+        finally:
+            PAGE_ALPHA.write_text(original_content, encoding="utf-8")
+
+
 class TestArchiveOrphans:
     """--archive-orphans removes pages no longer tracked in the directory."""
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1169,6 +1169,195 @@ class TestStateSaveAfterTreeDeploy:
 # ---------------------------------------------------------------------------
 
 
+class TestChangedOnlyEarlyExit:
+    """--changed-only with 0 changes must exit before any deploy or archive."""
+
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("ccfm_convert.main.deploy_tree")
+    def test_zero_changes_does_not_call_deploy_tree(
+        self, mock_deploy_tree, mock_api_class, tmp_path, capsys
+    ):
+        """When --changed-only reports 0 changes, deploy_tree must not be called."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        unchanged = docs / "unchanged.md"
+        unchanged.write_text("# Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = []
+
+        from ccfm_convert.state.manager import StateManager
+
+        state_file = tmp_path / ".ccfm-state.json"
+        original = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            sm = StateManager(state_file)
+            unchanged_rel = str(unchanged.relative_to(tmp_path))
+            sm.set_page(unchanged_rel, "p1", "Unchanged", "TEST", "s1", sm.compute_hash(unchanged))
+            sm.save()
+
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "tok",
+                    "--space",
+                    "TEST",
+                    "--directory",
+                    str(docs),
+                    "--changed-only",
+                    "--state",
+                    str(state_file),
+                ],
+            ):
+                main.main()
+        finally:
+            os.chdir(original)
+
+        mock_deploy_tree.assert_not_called()
+        captured = capsys.readouterr()
+        assert "No changes to deploy" in captured.out
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("ccfm_convert.main.deploy_tree")
+    def test_zero_changes_does_not_archive_pages(
+        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path
+    ):
+        """When --changed-only reports 0 changes, --archive-orphans must not run."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        unchanged = docs / "unchanged.md"
+        unchanged.write_text("# Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = []
+
+        from ccfm_convert.state.manager import StateManager
+
+        state_file = tmp_path / ".ccfm-state.json"
+        original = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            sm = StateManager(state_file)
+            unchanged_rel = str(unchanged.relative_to(tmp_path))
+            sm.set_page(unchanged_rel, "p1", "Unchanged", "TEST", "s1", sm.compute_hash(unchanged))
+            sm.save()
+
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "tok",
+                    "--space",
+                    "TEST",
+                    "--directory",
+                    str(docs),
+                    "--changed-only",
+                    "--archive-orphans",
+                    "--state",
+                    str(state_file),
+                ],
+            ):
+                main.main()
+        finally:
+            os.chdir(original)
+
+        mock_deploy_tree.assert_not_called()
+        mock_archive.assert_not_called()
+
+
+class TestChangedOnlyWithArchiveOrphans:
+    """--changed-only + --archive-orphans: orphan detection uses all disk files, not just changed ones."""
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("ccfm_convert.main.deploy_tree")
+    def test_unchanged_files_on_disk_are_not_treated_as_orphans(
+        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path
+    ):
+        """Unchanged files still present on disk must not be archived even if
+        --changed-only excludes them from the deploy set.
+
+        Regression test for issue #3 (Bug 2): find_orphans must receive all current
+        disk files, not the --changed-only-filtered subset.
+        """
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        changed = docs / "changed.md"
+        unchanged = docs / "unchanged.md"
+        changed.write_text("# New Content")
+        unchanged.write_text("# Stable Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = [(changed, "changed-pid")]
+        mock_archive.return_value = True
+
+        from ccfm_convert.state.manager import StateManager
+
+        state_file = tmp_path / ".ccfm-state.json"
+        original = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            sm = StateManager(state_file)
+            unchanged_rel = str(unchanged.relative_to(tmp_path))
+            # 'unchanged' is already in state with a matching hash → has_changed=False
+            sm.set_page(
+                unchanged_rel,
+                "unchanged-pid",
+                "Unchanged",
+                "TEST",
+                "s1",
+                sm.compute_hash(unchanged),
+            )
+            sm.save()
+
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "tok",
+                    "--space",
+                    "TEST",
+                    "--directory",
+                    str(docs),
+                    "--changed-only",
+                    "--archive-orphans",
+                    "--state",
+                    str(state_file),
+                ],
+            ):
+                main.main()
+        finally:
+            os.chdir(original)
+
+        # 'unchanged.md' is on disk — must not be archived even though it was
+        # excluded from target_files by --changed-only
+        mock_archive.assert_not_called()
+
+
 class TestArchiveOrphansLiveDeploy:
     @patch("ccfm_convert.main.archive_page")
     @patch("ccfm_convert.main.ConfluenceAPI")


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #3 that combine to destroy a Confluence space on a no-op re-deploy.

**Bug 1 — no early exit when 0 files changed**
`--changed-only` filtered `target_files` to an empty list but the code continued to call `deploy_tree()`, which re-discovers all markdown files from the directory itself and deploys everything regardless.

**Bug 2 — orphan detection used the filtered file list**
`find_orphans()` was called with `target_files` (the `--changed-only` filtered subset). When that list was empty (or partial), every page in state looked like an orphan and was archived.

## Fix (`src/ccfm_convert/main.py`)

- **Early return**: after the `--changed-only` filter, if `not target_files` → print `No changes to deploy.` and `return`. Stops the deploy and orphan archiving entirely.
- **`all_files` snapshot**: captured before the `--changed-only` filter and passed to `find_orphans()` instead of `target_files`. Unchanged files on disk are never mistaken for orphans.

## Tests

- `TestChangedOnlyEarlyExit` (unit) — `deploy_tree` not called on 0 changes; `archive_page` not called even with `--archive-orphans`
- `TestChangedOnlyWithArchiveOrphans` (unit) — unchanged files on disk are not archived when excluded by `--changed-only`
- `TestChangedOnlyWithArchiveOrphans` (smoke) — exact reproduction of issue #3: no-op re-deploy leaves all pages intact; one-file-changed run doesn't archive the unchanged file

## Test plan

- [x] `pytest -x -q` — 461 tests pass, 100% coverage
- [x] Smoke: deploy both pages, re-run with `--changed-only --archive-orphans`, confirm no pages archived
- [x] Smoke: modify one file, re-run with `--changed-only --archive-orphans`, confirm only that file updated, other pages untouched

Closes #3