### PR TITLE
feat(state): remote state locking and extended state/lock CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ legacy conversions, no storage format hacks, full editor compatibility.
 - **Automatic page hierarchy** — Directory structure maps directly to Confluence page hierarchy
 - **CCFM extensions** — Status badges, panels, expands, dates, smart page links, emoji, image width control
 - **Idempotent** — Safe to run multiple times; creates or updates pages automatically
+- **Remote state** — Deployment state stored in Confluence itself, no local files to commit
+- **Concurrent deploy protection** — Terraform-style locking prevents conflicting deploys
 - **CI/CD ready** — Deploy documentation on every commit to your main branch
 
 Full syntax reference: **[CCFM.md](CCFM.md)**
@@ -34,7 +36,26 @@ create a token, and note your Atlassian email address.
 pip install ccfm-convert
 ```
 
-### 3. Write a page
+### 3. Initialise your space
+
+Before deploying for the first time, initialise CCFM in your Confluence space. This creates
+a `_ccfm` management page that stores deployment state and lock information.
+
+```bash
+ccfm \
+  --domain your-domain.atlassian.net \
+  --email your.email@example.com \
+  --token YOUR_API_TOKEN \
+  --space YOUR_SPACE_KEY \
+  init
+```
+
+This is idempotent — safe to run multiple times. It creates:
+
+- A `_ccfm` container page at the space root
+- A `CCFM State Management` child page (tagged with `ccfm-internal` label)
+
+### 4. Write a page
 
 ```markdown
 ---
@@ -57,7 +78,7 @@ This is **bold** text, this is *italic*.
 ::In Progress::blue::   ::Stable::green::
 ```
 
-### 4. Deploy
+### 5. Deploy
 
 ```bash
 # Deploy a single file
@@ -66,7 +87,7 @@ ccfm \
   --email your.email@example.com \
   --token YOUR_API_TOKEN \
   --space YOUR_SPACE_KEY \
-  --file path/to/my-page.md
+  deploy --file path/to/my-page.md
 
 # Deploy a directory recursively
 ccfm \
@@ -74,19 +95,15 @@ ccfm \
   --email your.email@example.com \
   --token YOUR_API_TOKEN \
   --space YOUR_SPACE_KEY \
-  --directory path/to/docs
+  deploy --directory path/to/docs
 ```
 
-### 5. Inspect before deploying
+### 6. Inspect before deploying
 
 Use `--dump` to write ADF JSON files locally without making any API calls:
 
 ```bash
-ccfm \
-  --domain your-domain.atlassian.net \
-  --email your.email@example.com \
-  --token YOUR_API_TOKEN \
-  --space YOUR_SPACE_KEY \
+ccfm deploy \
   --file path/to/my-page.md \
   --dump
 # Writes path/to/my-page.adf.json for inspection
@@ -127,103 +144,197 @@ See [CCFM.md — Front matter](CCFM.md#front-matter) for the complete field refe
 
 ## CLI Reference
 
+CCFM uses subcommands. Global credential options must come **before** the subcommand:
+
 ```text
-ccfm [OPTIONS]
+ccfm [GLOBAL OPTIONS] <command> [COMMAND OPTIONS]
 
-Required (not needed for --plan or --dump):
-  --domain DOMAIN          Confluence domain (e.g., company.atlassian.net)
-  --email EMAIL            User email address
-  --token TOKEN            Atlassian API token (or set CONFLUENCE_TOKEN env var)
-  --space SPACE            Space key (e.g., DOCS — not the space display name)
+Commands:
+  init                   Initialise remote state in a Confluence space
+  deploy                 Deploy markdown files to Confluence
+  state list             List all pages tracked in remote state
+  state pull             Print remote state JSON to stdout
+  state push <file>      Overwrite remote state from a local file
+  state rm <path>        Remove a page entry from remote state
+  state show <path>      Show state entry for a specific path
+  lock acquire           Manually acquire the remote lock
+  lock status            Show current lock status
+  lock release           Force-release a stale lock
 
-Deployment targets (one required):
-  --file PATH              Deploy a single markdown file
-  --directory PATH         Deploy a directory recursively
+Global options (apply to all commands):
+  --config PATH          Path to ccfm.yaml config file (default: ccfm.yaml if present)
+  --domain DOMAIN        Confluence domain (e.g., company.atlassian.net)
+  --email EMAIL          User email address
+  --token TOKEN          Atlassian API token (or set CONFLUENCE_TOKEN env var)
+  --space SPACE          Space key (e.g., DOCS — not the space display name)
+```
+
+### Deploy options
+
+```text
+ccfm deploy [OPTIONS]
+
+Deployment targets (one required unless --dump):
+  --file PATH            Deploy a single markdown file
+  --directory PATH       Deploy a directory recursively
 
 Options:
-  --config PATH            Path to ccfm.yaml config file (default: ccfm.yaml if present)
-  --state PATH             Path to state file (default: .ccfm-state.json)
-  --docs-root PATH         Documentation root directory (default: docs)
-  --git-repo-url URL       Git repo URL for CI banner source links
-  --dump                   Write ADF to .adf.json files, skip deployment
-  --plan                   Show what would be deployed without making any changes
-  --changed-only           Only deploy files whose content has changed since last deploy
-  --archive-orphans        Archive Confluence pages for markdown files removed from disk
+  --docs-root PATH       Documentation root directory (default: docs)
+  --git-repo-url URL     Git repo URL for CI banner source links
+  --dump                 Write ADF to .adf.json files, skip deployment
+  --plan                 Show what would be deployed without making changes
+  --plan-exit-code       Exit 2 when plan detects pending changes (for CI gates)
+  --changed-only         Only deploy files whose content has changed
+  --archive-orphans      Archive pages for markdown files removed from disk
+  --lock-id ID           Lock identifier for CI traceability (e.g., pipeline ID)
 ```
 
 ### Examples
 
 ```bash
+# Initialise CCFM in your space (one-time setup)
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS init
+
 # Deploy a single file
-ccfm \
-  --domain company.atlassian.net \
-  --email user@example.com \
-  --token abc123 \
-  --space DOCS \
-  --file path/to/api/authentication.md
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
+  deploy --file path/to/api/authentication.md
 
 # Deploy entire docs folder
-ccfm \
-  --domain company.atlassian.net \
-  --email user@example.com \
-  --token abc123 \
-  --space DOCS \
-  --directory path/to/docs
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
+  deploy --directory path/to/docs
 
 # With CI banner links back to source files
-ccfm \
-  --domain company.atlassian.net \
-  --email user@example.com \
-  --token abc123 \
-  --space DOCS \
-  --directory path/to/docs \
-  --git-repo-url "https://github.com/org/repo/blob/main"
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
+  deploy --directory path/to/docs --git-repo-url "https://github.com/org/repo/blob/main"
+
+# Preview changes without deploying (credentials from ccfm.yaml)
+ccfm deploy --directory docs --plan
+
+# Check lock status
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
+  lock status
+
+# View tracked pages
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
+  state list
 ```
 
 ---
 
 ## State Management
 
-CCFM tracks deployed pages in a local `.ccfm-state.json` file. This enables:
+CCFM stores deployment state remotely in Confluence itself — no local state files to commit
+or sync. State is stored as a `ccfm-state.json` attachment on the `CCFM State Management`
+page, which lives under a `_ccfm` container page in your space.
+
+This enables:
 
 - **Plan mode** — see what would change before deploying
 - **Changed-only deploys** — skip files with no content changes (faster CI)
 - **Orphan archiving** — archive pages whose source files have been deleted
+- **No checkin loops** — state changes don't trigger CI rebuilds
+- **No merge conflicts** — concurrent deploys don't fight over a state file
 
-**Commit the state file** alongside your documentation. Team members and CI pipelines
-share the same deployment history through version control.
+### Initialising
+
+Run `ccfm init` before your first deploy. This creates the management infrastructure
+in your Confluence space:
 
 ```bash
-# Preview what would be deployed (no API calls made)
-ccfm \
-  --domain company.atlassian.net \
-  --email user@example.com \
-  --token abc123 \
-  --space DOCS \
-  --directory docs \
-  --plan
-
-# Only deploy changed files (faster CI runs)
-ccfm \
-  --domain company.atlassian.net \
-  --email user@example.com \
-  --token abc123 \
-  --space DOCS \
-  --directory docs \
-  --changed-only
-
-# Archive pages whose source markdown files were deleted
-ccfm \
-  --domain company.atlassian.net \
-  --email user@example.com \
-  --token abc123 \
-  --space DOCS \
-  --directory docs \
-  --archive-orphans
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS init
 ```
 
-`--plan` exits with code `2` when there are pending changes and `0` when everything is
-up to date — useful for CI gates.
+The command is idempotent — running it again is a no-op. It is a **one-time per-space** operation; you do not need to run it before every deploy.
+
+### Inspecting and managing state
+
+```bash
+# List all tracked pages
+ccfm --domain ... --email ... --token ... --space DOCS state list
+
+# Show full details for a specific entry
+ccfm --domain ... --email ... --token ... --space DOCS state show docs/my-page.md
+
+# Download the raw state JSON (useful for piping to jq or saving a backup)
+ccfm --domain ... --email ... --token ... --space DOCS state pull
+
+# Remove a specific entry (e.g., after manually deleting a page in Confluence)
+ccfm --domain ... --email ... --token ... --space DOCS state rm docs/old-page.md
+```
+
+#### Recovery: push a repaired state file
+
+If state becomes corrupted, download it, edit it locally, then push it back:
+
+```bash
+ccfm --domain ... --email ... --token ... --space DOCS state pull > state-backup.json
+# edit state-backup.json
+ccfm --domain ... --email ... --token ... --space DOCS state push state-backup.json
+```
+
+> **Warning:** `state push` overwrites the remote state completely. Use with caution.
+
+### Plan mode
+
+Preview what would change without making any modifications:
+
+```bash
+ccfm deploy --directory docs --plan
+```
+
+Use `--plan-exit-code` to exit with code `2` when there are pending changes — useful
+for CI gates that block merges until docs are deployed.
+
+---
+
+## Locking
+
+CCFM uses Terraform-style locking to prevent concurrent deploys from corrupting state or
+creating duplicate pages. Locks are stored as a content property on the management page,
+using Confluence's optimistic concurrency (version numbers) to prevent race conditions.
+
+### How it works
+
+- `ccfm deploy` automatically acquires a lock before deploying and releases it when done
+- If another deploy is in progress, the command fails immediately with a lock error
+- `--plan` and `--dump` modes do **not** acquire locks (they're read-only)
+- Lock owner is auto-detected as `user@hostname`
+
+### CI traceability
+
+Pass `--lock-id` to associate the lock with a CI pipeline for easier debugging:
+
+```bash
+ccfm --space DOCS deploy --directory docs --lock-id "$CI_PIPELINE_ID"
+```
+
+### Checking lock status
+
+```bash
+ccfm --domain ... --email ... --token ... --space DOCS lock status
+```
+
+Output shows whether the lock is held, by whom, when it was acquired, and the lock ID.
+
+### Manually acquiring the lock
+
+For maintenance or scripted workflows, acquire the lock without deploying:
+
+```bash
+ccfm --domain ... --email ... --token ... --space DOCS lock acquire
+
+# With a custom operation label and lock ID
+ccfm --domain ... --email ... --token ... --space DOCS \
+  lock acquire --operation maintenance --lock-id "manual-$(date +%s)"
+```
+
+### Recovering from stale locks
+
+If a CI job crashes mid-deploy, the lock may be left in place. Force-release it:
+
+```bash
+ccfm --domain ... --email ... --token ... --space DOCS lock release
+```
 
 ---
 
@@ -241,14 +352,13 @@ token: ${CONFLUENCE_TOKEN}
 space: DOCS
 docs_root: docs
 git_repo_url: https://github.com/org/repo
-state_file: .ccfm-state.json
 ```
 
 With a config file in place:
 
 ```bash
-ccfm --directory docs --plan
-ccfm --directory docs
+ccfm deploy --directory docs --plan
+ccfm deploy --directory docs
 ```
 
 **Security note:** `ccfm.yaml` is a trusted-author file. Any environment variable
@@ -268,7 +378,7 @@ docker run --rm \
   -e CONFLUENCE_TOKEN=your-token \
   -v $(pwd)/docs:/docs \
   ghcr.io/stevesimpson418/ccfm-convert:latest \
-  --space DOCS --directory /docs
+  deploy --space DOCS --directory /docs
 ```
 
 ---
@@ -284,6 +394,76 @@ docker run --rm \
     space:  DOCS
     directory: docs
     args: --changed-only
+```
+
+---
+
+## CI/CD
+
+Store credentials as secrets: `CONFLUENCE_DOMAIN`, `CONFLUENCE_EMAIL`, `CONFLUENCE_TOKEN`.
+
+### Pipeline overview
+
+Every PR targeting `main` runs three gates:
+
+| Check | When | Blocks merge? |
+| --- | --- | --- |
+| Lint + unit tests (100% coverage) | Every push / PR commit | Yes |
+| Smoke tests against CCFMDEV space | PRs + pushes touching `src/` or `tests/smoke/` | Yes |
+| Markdown lint | Every push / PR commit | Yes |
+
+Smoke tests auto-cleanup Confluence pages after each run. For manual inspection
+runs (leave pages in Confluence), use **Actions > Smoke Tests > Run workflow** and
+uncheck *Delete Confluence pages after tests*.
+
+Set these required status checks in GitHub > Settings > Branches > main:
+
+- `Lint`, `Test`, `Markdown Lint`, `Smoke Tests (CCFMDEV)`
+
+### Deploying your docs via GitHub Actions
+
+```yaml
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install ccfm-convert
+      - env:
+          CONFLUENCE_DOMAIN: ${{ secrets.CONFLUENCE_DOMAIN }}
+          CONFLUENCE_EMAIL: ${{ secrets.CONFLUENCE_EMAIL }}
+          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
+        run: |
+          # Ensure management page exists (idempotent)
+          ccfm \
+            --domain "$CONFLUENCE_DOMAIN" \
+            --email "$CONFLUENCE_EMAIL" \
+            --token "$CONFLUENCE_TOKEN" \
+            --space DOCS \
+            init
+
+          # Deploy with lock ID for CI traceability
+          ccfm \
+            --domain "$CONFLUENCE_DOMAIN" \
+            --email "$CONFLUENCE_EMAIL" \
+            --token "$CONFLUENCE_TOKEN" \
+            --space DOCS \
+            deploy \
+            --directory docs \
+            --git-repo-url "https://github.com/${{ github.repository }}/blob/main" \
+            --changed-only \
+            --lock-id "${{ github.run_id }}"
 ```
 
 ---
@@ -315,65 +495,6 @@ custom titles.
 
 ---
 
-## CI/CD
-
-Store credentials as secrets: `CONFLUENCE_DOMAIN`, `CONFLUENCE_EMAIL`, `CONFLUENCE_TOKEN`.
-
-### Pipeline overview
-
-Every PR targeting `main` runs three gates:
-
-| Check | When | Blocks merge? |
-| --- | --- | --- |
-| Lint + unit tests (100% coverage) | Every push / PR commit | Yes |
-| Smoke tests against CCFMDEV space | PRs + pushes touching `src/` or `tests/smoke/` | Yes |
-| Markdown lint | Every push / PR commit | Yes |
-
-Smoke tests auto-cleanup Confluence pages after each run. For manual inspection
-runs (leave pages in Confluence), use **Actions → Smoke Tests → Run workflow** and
-uncheck *Delete Confluence pages after tests*.
-
-Set these required status checks in GitHub → Settings → Branches → main:
-
-- `Lint`, `Test`, `Markdown Lint`, `Smoke Tests (CCFMDEV)`
-
-### Deploying your docs via GitHub Actions
-
-```yaml
-name: Deploy Docs
-
-on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install ccfm-convert
-      - env:
-          CONFLUENCE_DOMAIN: ${{ secrets.CONFLUENCE_DOMAIN }}
-          CONFLUENCE_EMAIL: ${{ secrets.CONFLUENCE_EMAIL }}
-          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
-        run: |
-          ccfm \
-            --domain "$CONFLUENCE_DOMAIN" \
-            --email "$CONFLUENCE_EMAIL" \
-            --token "$CONFLUENCE_TOKEN" \
-            --space DOCS \
-            --directory docs \
-            --git-repo-url "https://github.com/${{ github.repository }}/blob/main" \
-            --changed-only
-```
-
----
-
 ## Project Structure
 
 ```text
@@ -386,24 +507,26 @@ jobs:
 │       │   ├── blocks.py         # Block markdown parsing
 │       │   └── converter.py      # Orchestration; convert() entry point
 │       ├── deploy/               # Confluence API and deployment logic
-│       │   ├── api.py            # ConfluenceAPI class (REST v2 + v1 for attachments)
+│       │   ├── api.py            # ConfluenceAPI class (REST v2 + v1 for attachments/properties)
 │       │   ├── frontmatter.py    # YAML frontmatter parsing
 │       │   ├── orchestration.py  # deploy_page(), deploy_tree(), archive_page()
 │       │   └── transforms.py     # CI banner, page link resolution, attachment media nodes
-│       ├── state/                # Deployment state persistence
-│       │   └── manager.py        # StateManager — filepath → page_id mapping, content hashing
+│       ├── state/                # Remote state and locking
+│       │   ├── backend.py        # StateBackend protocol + ConfluenceBackend
+│       │   ├── manager.py        # StateManager — filepath → page_id mapping, content hashing
+│       │   ├── lock.py           # LockManager — Terraform-style deploy locking
+│       │   └── init.py           # init_remote_state() — one-time space setup
 │       ├── config/               # Project config file loader
 │       │   └── loader.py         # ccfm.yaml loader with ${ENV_VAR} interpolation
 │       ├── plan/                 # Plan/diff mode
 │       │   └── planner.py        # compute_plan(), DeployPlan — terraform-style diff output
-│       └── main.py               # CLI entry point (argparse)
+│       └── main.py               # CLI entry point (argparse subcommands)
 ├── tests/
 │   ├── smoke/                # End-to-end smoke tests (real Confluence space)
 │   │   ├── conftest.py       # Credentials, cleanup hook, ccfm_run fixture
 │   │   ├── docs/             # Fixture markdown files deployed during smoke tests
 │   │   └── test_*.py         # Smoke test modules
 │   └── test_*.py             # Unit tests (100% coverage, all mocked)
-├── .ccfm-state.json          # Deployment state (commit this alongside your docs)
 ├── ccfm.yaml                 # Optional project config (credentials, space, docs_root)
 ├── CCFM.md                   # Complete CCFM syntax and ADF mapping reference
 ├── requirements.txt          # Runtime dependencies
@@ -460,7 +583,7 @@ pytest tests/smoke/ --no-cov -v --no-cleanup
 pytest tests/smoke/ --no-cov -v --cleanup-only
 ```
 
-**GitHub Actions:** Go to Actions → Smoke Tests → Run workflow (manual trigger).
+**GitHub Actions:** Go to Actions > Smoke Tests > Run workflow (manual trigger).
 Requires `CONFLUENCE_DOMAIN`, `CONFLUENCE_EMAIL`, and `CONFLUENCE_TOKEN` secrets.
 Uncheck "Delete Confluence pages after tests" to leave pages for manual inspection.
 
@@ -499,6 +622,16 @@ No I/O, no network calls. Entry point: `convert(markdown: str) -> dict`.
 - `transforms.py` — Post-conversion ADF mutations: CI banner injection, internal page link
   resolution, attachment media node rewriting
 
+### `src/ccfm_convert/state/` — Remote state and locking
+
+- `backend.py` — `StateBackend` protocol with `load()`/`save()` methods;
+  `ConfluenceBackend` stores state as a JSON attachment on the management page
+- `manager.py` — `StateManager` tracks deployed pages, computes content hashes,
+  detects orphaned pages. Backend-agnostic via `StateBackend` protocol
+- `lock.py` — `LockManager` implements Terraform-style locking using Confluence content
+  properties with optimistic concurrency (409 Conflict = race condition)
+- `init.py` — `init_remote_state()` creates the `_ccfm` management infrastructure
+
 ### Attachment upload flow
 
 Confluence's v2 API lacks an attachment POST endpoint, so the deploy tool uses a multi-step
@@ -521,6 +654,19 @@ create/edit permissions in the target space.
 **Space not found**
 Use the space **key** (e.g., `DOCS`), not the display name. The key appears in the URL:
 `/wiki/spaces/DOCS/`.
+
+**"Run `ccfm init` first"**
+The management page was not found in your space. Run `ccfm init` to create the `_ccfm`
+container and state management page.
+
+**Deploy blocked by lock**
+Another deploy is in progress (or a previous deploy crashed without releasing the lock).
+Check the lock status and force-release if the lock is stale:
+
+```bash
+ccfm --domain ... --email ... --token ... --space DOCS lock status
+ccfm --domain ... --email ... --token ... --space DOCS lock release
+```
 
 **Image not rendering after redeploy**
 The Confluence v1 attachment update endpoint returns a different response shape than the create

--- a/src/ccfm_convert/config/loader.py
+++ b/src/ccfm_convert/config/loader.py
@@ -12,7 +12,6 @@ Supported schema:
     space: DOCS
     docs_root: docs
     git_repo_url: https://github.com/org/repo
-    state_file: .ccfm-state.json
 
     # Optional multi-space routing
     deployments:
@@ -46,7 +45,6 @@ _CONFIG_TO_ARG = {
     "space": "space",
     "docs_root": "docs_root",
     "git_repo_url": "git_repo_url",
-    "state_file": "state",
 }
 
 

--- a/src/ccfm_convert/deploy/api.py
+++ b/src/ccfm_convert/deploy/api.py
@@ -3,11 +3,24 @@
 import json
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Default timeout (seconds) for all Confluence API calls.
 # Prevents CI jobs hanging indefinitely when the API is slow or unresponsive.
 REQUEST_TIMEOUT = 30
 UPLOAD_TIMEOUT = 60  # File uploads may be slower for large attachments
+
+# Retry configuration for transient network errors and server-side rate limiting.
+# POST is intentionally excluded: create_page and other POSTs are non-idempotent
+# and retrying on 5xx would silently create duplicate pages.
+_RETRY_STRATEGY = Retry(
+    total=3,
+    backoff_factor=1,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["HEAD", "GET", "PUT", "DELETE", "OPTIONS"],
+    raise_on_status=False,
+)
 
 
 class ConfluenceAPI:
@@ -19,13 +32,17 @@ class ConfluenceAPI:
         self.token = token
         self.base_url = f"https://{domain}/wiki/api/v2"
         self.auth = (email, token)
+        adapter = HTTPAdapter(max_retries=_RETRY_STRATEGY)
+        self._session = requests.Session()
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
 
     def get_space_id(self, space_key):
         """Get space ID from space key."""
         url = f"{self.base_url}/spaces"
         params = {"keys": space_key}
 
-        response = requests.get(
+        response = self._session.get(
             url,
             params=params,
             auth=self.auth,
@@ -50,7 +67,7 @@ class ConfluenceAPI:
         url = f"{self.base_url}/pages"
         params = {"space-id": space_id, "title": title, "limit": 1}
 
-        response = requests.get(
+        response = self._session.get(
             url,
             params=params,
             auth=self.auth,
@@ -78,7 +95,7 @@ class ConfluenceAPI:
         url = f"{self.base_url}/pages"
         params = {"space-id": space_id, "title": title, "limit": 1}
 
-        response = requests.get(
+        response = self._session.get(
             url,
             params=params,
             auth=self.auth,
@@ -111,7 +128,7 @@ class ConfluenceAPI:
         if parent_id:
             data["parentId"] = parent_id
 
-        response = requests.post(
+        response = self._session.post(
             url,
             json=data,
             auth=self.auth,
@@ -136,7 +153,7 @@ class ConfluenceAPI:
         """Update an existing page."""
         # Get current version
         url = f"{self.base_url}/pages/{page_id}"
-        response = requests.get(
+        response = self._session.get(
             url,
             auth=self.auth,
             headers={"Accept": "application/json"},
@@ -161,7 +178,7 @@ class ConfluenceAPI:
             },
         }
 
-        response = requests.put(
+        response = self._session.put(
             update_url,
             json=data,
             auth=self.auth,
@@ -187,7 +204,7 @@ class ConfluenceAPI:
 
         label_data = [{"prefix": "global", "name": label} for label in all_labels]
 
-        response = requests.post(
+        response = self._session.post(
             url,
             json=label_data,
             auth=self.auth,
@@ -216,7 +233,7 @@ class ConfluenceAPI:
         """
         url = f"{self.base_url}/attachments/{attachment_id}"
 
-        response = requests.get(
+        response = self._session.get(
             url,
             auth=self.auth,
             headers={"Accept": "application/json"},
@@ -244,7 +261,7 @@ class ConfluenceAPI:
             requests.HTTPError: if the API returns a non-2xx response.
         """
         url = f"{self.base_url}/pages/{page_id}"
-        response = requests.delete(
+        response = self._session.delete(
             url,
             auth=self.auth,
             headers={"Accept": "application/json"},
@@ -252,7 +269,164 @@ class ConfluenceAPI:
         )
         response.raise_for_status()
 
-    def upload_attachment(self, page_id, filepath, alt_text=None):
+    # ------------------------------------------------------------------
+    # Content properties (v1 API) — used for state locking
+    # ------------------------------------------------------------------
+
+    def get_content_property(self, page_id, key):
+        """Get a content property by key.
+
+        Returns:
+            Property dict (contains 'value' and 'version') or None if not found.
+        """
+        url = f"https://{self.domain}/wiki/rest/api/content/{page_id}/property/{key}"
+        response = self._session.get(
+            url,
+            auth=self.auth,
+            headers={"Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+    def set_content_property(self, page_id, key, value, version=None):
+        """Create or update a content property.
+
+        When version is None, creates (POST). When version is provided, updates
+        (PUT) with optimistic concurrency — Confluence returns 409 if the version
+        has been changed by another process.
+        """
+        url = f"https://{self.domain}/wiki/rest/api/content/{page_id}/property/{key}"
+        data = {"key": key, "value": value}
+        if version is not None:
+            data["version"] = {"number": version, "minorEdit": True}
+            response = self._session.put(
+                url,
+                json=data,
+                auth=self.auth,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                timeout=REQUEST_TIMEOUT,
+            )
+        else:
+            response = self._session.post(
+                url,
+                json=data,
+                auth=self.auth,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                timeout=REQUEST_TIMEOUT,
+            )
+        response.raise_for_status()
+
+    def delete_content_property(self, page_id, key):
+        """Delete a content property. No-op if already absent."""
+        url = f"https://{self.domain}/wiki/rest/api/content/{page_id}/property/{key}"
+        response = self._session.delete(
+            url,
+            auth=self.auth,
+            headers={"Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+
+    # ------------------------------------------------------------------
+    # Attachment download (v1 API) — used for remote state
+    # ------------------------------------------------------------------
+
+    def download_attachment(self, page_id, filename):
+        """Download an attachment's content by filename.
+
+        Returns:
+            Raw bytes of the attachment, or None if not found.
+        """
+        list_url = f"https://{self.domain}/wiki/rest/api/content/{page_id}/child/attachment"
+        resp = self._session.get(
+            list_url,
+            params={"filename": filename},
+            auth=self.auth,
+            headers={"Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        if not results:
+            return None
+
+        download_path = results[0]["_links"]["download"]
+        download_url = f"https://{self.domain}/wiki{download_path}"
+        resp = self._session.get(download_url, auth=self.auth, timeout=UPLOAD_TIMEOUT)
+        resp.raise_for_status()
+        return resp.content
+
+    # ------------------------------------------------------------------
+    # Page discovery by parent/child (v2 API) — used to find management page
+    # ------------------------------------------------------------------
+
+    def find_child_page_by_title(self, parent_id: str, title: str) -> str | None:
+        """Find a direct child page of parent_id by exact title.
+
+        Paginates through children if needed (cursor-based). Returns the first
+        match, or None if no child with that title exists.
+
+        Returns:
+            Page ID if found, None otherwise.
+        """
+        url = f"{self.base_url}/pages/{parent_id}/children"
+        params: dict = {"limit": 50}
+        while True:
+            response = self._session.get(
+                url,
+                params=params,
+                auth=self.auth,
+                headers={"Accept": "application/json"},
+                timeout=REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            data = response.json()
+            for page in data.get("results", []):
+                if page.get("title") == title:
+                    return page["id"]
+            next_url = data.get("_links", {}).get("next")
+            if not next_url:
+                break
+            # next_url is a relative path; prepend the base wiki URL
+            url = f"https://{self.domain}/wiki{next_url}"
+            params = {}
+        return None
+
+    # ------------------------------------------------------------------
+    # Page discovery by label (v1 API) — retained for external tooling
+    # ------------------------------------------------------------------
+
+    def find_page_by_label(self, space_key, label):
+        """Find a page by label in a space.
+
+        Returns:
+            Page ID if found, None otherwise.
+        """
+        url = f"https://{self.domain}/wiki/rest/api/content"
+        params = {"type": "page", "spaceKey": space_key, "label": label, "limit": 1}
+        response = self._session.get(
+            url,
+            params=params,
+            auth=self.auth,
+            headers={"Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        results = response.json().get("results", [])
+        if not results:
+            return None
+        return results[0]["id"]
+
+    # ------------------------------------------------------------------
+    # Attachments
+    # ------------------------------------------------------------------
+
+    def upload_attachment(self, page_id, filepath, alt_text=None, name=None):
         """
         Upload attachment to page using v1 API.
 
@@ -265,11 +439,12 @@ class ConfluenceAPI:
             Dict with v1 attachment response (contains 'id' but not 'fileId')
         """
         url = f"https://{self.domain}/wiki/rest/api/content/{page_id}/child/attachment"
+        attachment_name = name or filepath.name
 
         # Check if attachment already exists
-        response = requests.get(
+        response = self._session.get(
             url,
-            params={"filename": filepath.name},
+            params={"filename": attachment_name},
             auth=self.auth,
             timeout=REQUEST_TIMEOUT,
         )
@@ -287,8 +462,8 @@ class ConfluenceAPI:
             upload_url = url
 
         with open(filepath, "rb") as fh:
-            files = {"file": (filepath.name, fh)}
-            response = requests.post(
+            files = {"file": (attachment_name, fh)}
+            response = self._session.post(
                 upload_url,
                 files=files,
                 auth=self.auth,
@@ -297,7 +472,9 @@ class ConfluenceAPI:
             )
 
         if response.status_code not in [200, 201]:
-            print(f"   ⚠ Warning: Could not upload {filepath.name} (status {response.status_code})")
+            print(
+                f"   ⚠ Warning: Could not upload {attachment_name} (status {response.status_code})"
+            )
             return None
 
         result = response.json()

--- a/src/ccfm_convert/deploy/orchestration.py
+++ b/src/ccfm_convert/deploy/orchestration.py
@@ -25,29 +25,41 @@ def ensure_page_hierarchy(api, space_id, filepath, docs_root, git_repo_url=""):
         git_repo_url: Git repo URL for CI banner
 
     Returns:
-        Parent page ID for the file (the immediate parent page's ID)
+        Tuple of (parent_page_id, hierarchy_pages) where hierarchy_pages is a list of
+        (rel_path, page_id, title) for each directory container page created/found.
     """
     # Get relative path from docs root
     try:
         rel_path = filepath.relative_to(docs_root)
     except ValueError:
         # File is not under docs_root
-        return None
+        return None, []
 
     # Get directory path (everything except the filename)
     dir_path = rel_path.parent
 
     # If file is directly in docs root, no parent needed
     if str(dir_path) == ".":
-        return None
+        return None, []
 
     # Create each directory as a page in the hierarchy
     parts = dir_path.parts
     current_parent_id = None
+    hierarchy_pages: list[tuple[str, str, str]] = []
+
+    docs_root_resolved = docs_root.resolve()
 
     for i, dir_name in enumerate(parts):
         # Build path to this directory
         current_dir = docs_root / Path(*parts[: i + 1])
+
+        # Guard against symlinks that point outside docs_root
+        if not current_dir.resolve().is_relative_to(docs_root_resolved):
+            raise ValueError(
+                f"Directory '{current_dir}' resolves outside docs_root '{docs_root}'. "
+                "Symlinks that escape the docs root are not permitted."
+            )
+
         page_content_file = current_dir / ".page_content.md"
 
         # Determine title and body
@@ -116,7 +128,14 @@ def ensure_page_hierarchy(api, space_id, filepath, docs_root, git_repo_url=""):
                     labels.append(author_label)
                 api.add_labels(current_parent_id, labels)
 
-    return current_parent_id
+        # Record the hierarchy page using its path relative to cwd
+        try:
+            dir_rel_path = str(current_dir.resolve().relative_to(Path.cwd().resolve()))
+        except ValueError:
+            dir_rel_path = str(current_dir)
+        hierarchy_pages.append((dir_rel_path, current_parent_id, title))
+
+    return current_parent_id, hierarchy_pages
 
 
 def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False):
@@ -132,8 +151,9 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
         dump: If True, write ADF JSON files and skip deployment
 
     Returns:
-        List of (filepath, page_id) tuples. page_id is None if the page was
-        skipped (deploy_page: false in frontmatter) or if dump mode is active.
+        Tuple of (results, hierarchy_pages) where results is a list of
+        (filepath, page_id) tuples and hierarchy_pages is a deduplicated list of
+        (rel_path, page_id, title) for each directory container page.
     """
     md_files = sorted(root_path.rglob("*.md"))
 
@@ -143,12 +163,20 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
     print(f"\n📚 Found {len(md_files)} markdown files in tree")
 
     results: list[tuple[Path, str | None]] = []
+    all_hierarchy_pages: list[tuple[str, str, str]] = []
+    seen_dirs: set[str] = set()
 
     for filepath in md_files:
         try:
             # Ensure page hierarchy exists
             if not dump:
-                parent_id = ensure_page_hierarchy(api, space_id, filepath, root_path, git_repo_url)
+                parent_id, h_pages = ensure_page_hierarchy(
+                    api, space_id, filepath, root_path, git_repo_url
+                )
+                for hp in h_pages:
+                    if hp[0] not in seen_dirs:
+                        all_hierarchy_pages.append(hp)
+                        seen_dirs.add(hp[0])
             else:
                 parent_id = None
 
@@ -160,7 +188,7 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
             results.append((filepath, None))
             continue
 
-    return results
+    return results, all_hierarchy_pages
 
 
 def archive_page(api, page_id: str, title: str) -> bool:

--- a/src/ccfm_convert/main.py
+++ b/src/ccfm_convert/main.py
@@ -1,7 +1,9 @@
 """Confluence Markdown Deployer - CLI Entry Point."""
 
 import argparse
+import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -15,7 +17,14 @@ from ccfm_convert.deploy import (
 )
 from ccfm_convert.deploy.frontmatter import parse_frontmatter
 from ccfm_convert.plan import compute_plan
-from ccfm_convert.state import StateManager
+from ccfm_convert.state import (
+    ConfluenceBackend,
+    LockError,
+    LockManager,
+    StateManager,
+    init_remote_state,
+)
+from ccfm_convert.state.init import CONTAINER_PAGE_TITLE, MANAGEMENT_PAGE_TITLE
 
 
 def _rel_path(filepath: Path) -> str:
@@ -38,10 +47,8 @@ def _derive_title(filepath: Path) -> str:
     return filepath.stem.replace("-", " ").title()
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Deploy markdown to Confluence Cloud")
-
-    # Config file
+def _add_global_args(parser: argparse.ArgumentParser) -> None:
+    """Add global arguments shared across all subcommands."""
     parser.add_argument(
         "--config",
         type=Path,
@@ -49,8 +56,6 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Path to ccfm.yaml config file (default: ccfm.yaml if present)",
     )
-
-    # Confluence credentials
     parser.add_argument("--domain", default=None, help="Confluence domain")
     parser.add_argument("--email", default=None, help="User email")
     parser.add_argument(
@@ -60,64 +65,84 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--space", default=None, help="Space key")
 
-    # Deployment targets
-    parser.add_argument("--file", type=Path, help="Single markdown file to deploy")
-    parser.add_argument("--directory", type=Path, help="Directory to deploy (recursive)")
-    parser.add_argument(
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Deploy markdown to Confluence Cloud")
+    _add_global_args(parser)
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # -- deploy ----------------------------------------------------------
+    deploy_parser = subparsers.add_parser("deploy", help="Deploy markdown to Confluence")
+    deploy_parser.add_argument("--file", type=Path, help="Single markdown file to deploy")
+    deploy_parser.add_argument("--directory", type=Path, help="Directory to deploy (recursive)")
+    deploy_parser.add_argument(
         "--docs-root",
         type=Path,
         default=None,
         help="Root documentation directory (default: docs)",
     )
-    parser.add_argument("--git-repo-url", default="", help="Git repo URL for CI banner")
-
-    # Behaviour flags
-    parser.add_argument(
+    deploy_parser.add_argument("--git-repo-url", default="", help="Git repo URL for CI banner")
+    deploy_parser.add_argument(
         "--dump",
         action="store_true",
         help="Write ADF to .adf.json files and skip deployment",
     )
-    parser.add_argument(
+    deploy_parser.add_argument(
         "--plan",
         action="store_true",
         help="Show what would be deployed without making any changes",
     )
-    parser.add_argument(
+    deploy_parser.add_argument(
         "--plan-exit-code",
         action="store_true",
         help="With --plan, exit 2 when changes are pending (Terraform-style)",
     )
-    parser.add_argument(
+    deploy_parser.add_argument(
         "--changed-only",
         action="store_true",
         help="Only deploy files whose content has changed since last deploy",
     )
-    parser.add_argument(
+    deploy_parser.add_argument(
         "--archive-orphans",
         action="store_true",
         help="Archive Confluence pages for markdown files that no longer exist on disk",
     )
-
-    # State file
-    parser.add_argument(
-        "--state",
-        type=Path,
+    deploy_parser.add_argument(
+        "--lock-id",
         default=None,
-        metavar="PATH",
-        help="Path to state file (default: .ccfm-state.json)",
+        help="Lock identifier for CI traceability (default: user@hostname)",
     )
+
+    # -- init ------------------------------------------------------------
+    subparsers.add_parser("init", help="Initialize remote state infrastructure in the space")
+
+    # -- state -----------------------------------------------------------
+    state_parser = subparsers.add_parser("state", help="Inspect or modify remote state")
+    state_sub = state_parser.add_subparsers(dest="state_command")
+    state_sub.add_parser("list", help="List all tracked pages")
+    state_sub.add_parser("pull", help="Print remote state JSON to stdout")
+    state_push = state_sub.add_parser("push", help="Overwrite remote state from a local file")
+    state_push.add_argument("file", type=Path, help="Local JSON file to upload as new state")
+    state_rm = state_sub.add_parser("rm", help="Remove a state entry by path")
+    state_rm.add_argument("path", help="Relative path of the entry to remove")
+    state_show = state_sub.add_parser("show", help="Show state entry for a specific path")
+    state_show.add_argument("path", help="Relative path of the tracked page")
+
+    # -- lock ------------------------------------------------------------
+    lock_parser = subparsers.add_parser("lock", help="Manage the remote state lock")
+    lock_sub = lock_parser.add_subparsers(dest="lock_command")
+    lock_sub.add_parser("status", help="Show current lock status")
+    lock_sub.add_parser("release", help="Force-release the remote lock")
+    lock_acquire = lock_sub.add_parser("acquire", help="Manually acquire the remote lock")
+    lock_acquire.add_argument("--lock-id", default=None, help="Lock identifier")
+    lock_acquire.add_argument("--operation", default="manual", help="Operation label")
 
     return parser
 
 
-def main():
-    """CLI entry point."""
-    parser = _build_parser()
-    args = parser.parse_args()
-
-    # ------------------------------------------------------------------
-    # 1. Resolve and merge config file
-    # ------------------------------------------------------------------
+def _resolve_config(args):
+    """Merge config file values into args. Returns updated args."""
     config_path = args.config or Path("ccfm.yaml")
     if config_path.exists():
         try:
@@ -126,141 +151,362 @@ def main():
         except Exception as e:
             print(f"Error loading config file '{config_path}': {e}")
             sys.exit(1)
+    return args
 
-    # Apply defaults that depend on config resolution
-    if args.docs_root is None:
+
+def _require_credentials(args, parser):
+    """Validate that credentials are set. Exits on missing values."""
+    missing = [f"--{f}" for f in ("domain", "email", "space") if not getattr(args, f, None)]
+    if not args.token:
+        missing.append("--token (or CONFLUENCE_TOKEN env var)")
+    if missing:
+        parser.error(f"Missing required arguments: {', '.join(missing)}")
+
+
+def _create_api(args):
+    """Create and return a ConfluenceAPI instance."""
+    return ConfluenceAPI(args.domain, args.email, args.token)
+
+
+def _find_management_page(api, space_id):
+    """Find the CCFM management page via the _ccfm container. Returns page_id or exits.
+
+    Uses container → child lookup instead of label search so that orphaned
+    management pages from failed cleanups are never returned.
+    """
+    container_id = api.find_page_by_title(space_id, CONTAINER_PAGE_TITLE)
+    if container_id is None:
+        print("Error: CCFM has not been initialized in this space. " "Run `ccfm init` first.")
+        sys.exit(1)
+    page_id = api.find_child_page_by_title(container_id, MANAGEMENT_PAGE_TITLE)
+    if page_id is None:
+        print("Error: CCFM has not been initialized in this space. " "Run `ccfm init` first.")
+        sys.exit(1)
+    return page_id
+
+
+# ======================================================================
+# Subcommand handlers
+# ======================================================================
+
+
+def _handle_init(args, parser):
+    """Handle the 'init' subcommand."""
+    _require_credentials(args, parser)
+    api = _create_api(args)
+    print(f"Looking up space: {args.space}")
+    space_id = api.get_space_id(args.space)
+    init_remote_state(api, args.space, space_id)
+    print("\nInitialization complete!")
+
+
+def _handle_deploy(args, parser):
+    """Handle the 'deploy' subcommand."""
+    # Apply deploy-specific defaults
+    if not hasattr(args, "docs_root") or args.docs_root is None:
         args.docs_root = Path("docs")
-    if args.state is None:
-        args.state = Path(".ccfm-state.json")
 
-    # ------------------------------------------------------------------
-    # 2. Validate required credentials (not needed for --plan or --dump)
-    # ------------------------------------------------------------------
-    if not args.plan and not args.dump:
-        missing = [f"--{f}" for f in ("domain", "email", "space") if not getattr(args, f, None)]
-        if not args.token:
-            missing.append("--token (or CONFLUENCE_TOKEN env var)")
-        if missing:
-            parser.error(f"Missing required arguments: {', '.join(missing)}")
-    else:
-        # plan/dump still need domain/space for context messages, but won't call API
-        pass
-
-    # ------------------------------------------------------------------
-    # 3. Initialise state
-    # ------------------------------------------------------------------
-    state = StateManager(args.state)
-    state.load()
-
-    # ------------------------------------------------------------------
-    # 4. Resolve target files
-    # ------------------------------------------------------------------
-    if args.file:
+    # Resolve target files
+    if hasattr(args, "file") and args.file:
         target_files = [args.file]
-    elif args.directory:
+    elif hasattr(args, "directory") and args.directory:
         all_md = sorted(args.directory.rglob("*.md"))
         target_files = [f for f in all_md if f.name != ".page_content.md"]
     else:
         print("Error: Specify either --file or --directory")
         sys.exit(1)
 
-    # Snapshot all current on-disk files before any --changed-only filtering.
-    # Used for accurate orphan detection: orphans are files in state with no
-    # corresponding file on disk, not files excluded by --changed-only.
+    # Snapshot all files before --changed-only filtering (for orphan detection)
     all_files = list(target_files)
 
-    # ------------------------------------------------------------------
-    # 5. Plan mode — show diff and exit
-    # ------------------------------------------------------------------
-    if args.plan:
+    # --dump mode: no API, no state, no lock
+    if hasattr(args, "dump") and args.dump:
+        print("Dump mode — ADF will be written to .adf.json files, no deployment")
+        git_repo_url = getattr(args, "git_repo_url", "")
+        if hasattr(args, "file") and args.file:
+            deploy_page(None, None, None, args.file, git_repo_url, dump=True)
+        elif hasattr(args, "directory") and args.directory:
+            deploy_tree(None, None, args.directory, args.docs_root, git_repo_url, dump=True)
+        return
+
+    # All non-dump paths need credentials and API
+    _require_credentials(args, parser)
+    api = _create_api(args)
+    print(f"Looking up space: {args.space}")
+    space_id = api.get_space_id(args.space)
+    print(f"   Space ID: {space_id}")
+
+    # Find management page for state + locking
+    mgmt_page_id = _find_management_page(api, space_id)
+    backend = ConfluenceBackend(api, mgmt_page_id)
+    state = StateManager(backend)
+    state.load()
+
+    # --plan mode: read-only, no lock needed
+    if hasattr(args, "plan") and args.plan:
         plan = compute_plan(
             state=state,
             files=target_files,
             docs_root=args.docs_root,
-            archive_orphans=args.archive_orphans,
+            archive_orphans=getattr(args, "archive_orphans", False),
         )
         plan.print_summary()
-        if args.plan_exit_code:
+        if getattr(args, "plan_exit_code", False):
             sys.exit(2 if plan.has_changes() else 0)
         sys.exit(0)
 
-    # ------------------------------------------------------------------
-    # 6. Changed-only filter
-    # ------------------------------------------------------------------
-    if args.changed_only:
+    # --changed-only filter
+    if getattr(args, "changed_only", False):
         target_files = [f for f in target_files if state.has_changed(_rel_path(f), f)]
-        print(f"ℹ️  --changed-only: {len(target_files)} file(s) with changes")
+        print(f"--changed-only: {len(target_files)} file(s) with changes")
         if not target_files:
-            print("ℹ️  No changes to deploy.")
+            print("No changes to deploy.")
             return
 
-    # ------------------------------------------------------------------
-    # 7. Dump mode — write ADF locally, no API calls
-    # ------------------------------------------------------------------
-    if args.dump:
-        print("🔍 Dump mode — ADF will be written to .adf.json files, no deployment")
-        if args.file:
-            deploy_page(None, None, None, args.file, args.git_repo_url, dump=True)
-        elif args.directory:
-            deploy_tree(None, None, args.directory, args.docs_root, args.git_repo_url, dump=True)
-        return
+    # Acquire lock for live deployment
+    lock_mgr = LockManager(api, mgmt_page_id)
+    lock_id = getattr(args, "lock_id", None)
+    try:
+        lock_mgr.acquire(operation="deploy", lock_id=lock_id)
+    except LockError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
-    # ------------------------------------------------------------------
-    # 8. Live deployment
-    # ------------------------------------------------------------------
-    print(f"🔍 Looking up space: {args.space}")
-    api = ConfluenceAPI(args.domain, args.email, args.token)
-    space_id = api.get_space_id(args.space)
-    print(f"   Space ID: {space_id}")
-
-    if args.file:
-        parent_id = ensure_page_hierarchy(
-            api, space_id, args.file, args.docs_root, args.git_repo_url
-        )
-        page_id = deploy_page(api, space_id, parent_id, args.file, args.git_repo_url)
-        if page_id:
-            state.set_page(
-                rel_path=_rel_path(args.file),
-                page_id=page_id,
-                title=_derive_title(args.file),
-                space_key=args.space,
-                space_id=space_id,
-                content_hash=state.compute_hash(args.file),
+    git_repo_url = getattr(args, "git_repo_url", "")
+    try:
+        # Live deployment
+        if hasattr(args, "file") and args.file:
+            parent_id, hierarchy_pages = ensure_page_hierarchy(
+                api, space_id, args.file, args.docs_root, git_repo_url
             )
-            state.save()
-
-    elif args.directory:
-        results = deploy_tree(api, space_id, args.directory, args.docs_root, args.git_repo_url)
-        for filepath, page_id in results:
-            if page_id:
+            page_id = deploy_page(api, space_id, parent_id, args.file, git_repo_url)
+            for h_rel_path, h_page_id, h_title in hierarchy_pages:
                 state.set_page(
-                    rel_path=_rel_path(filepath),
-                    page_id=page_id,
-                    title=_derive_title(filepath),
+                    rel_path=h_rel_path,
+                    page_id=h_page_id,
+                    title=h_title,
                     space_key=args.space,
                     space_id=space_id,
-                    content_hash=state.compute_hash(filepath),
+                    content_hash="",
                 )
-                state.save()
+            if page_id:
+                state.set_page(
+                    rel_path=_rel_path(args.file),
+                    page_id=page_id,
+                    title=_derive_title(args.file),
+                    space_key=args.space,
+                    space_id=space_id,
+                    content_hash=state.compute_hash(args.file),
+                )
+            state.save()
 
-    # ------------------------------------------------------------------
-    # 9. Archive orphaned pages
-    # ------------------------------------------------------------------
-    if args.archive_orphans:
-        orphans = state.find_orphans(all_files, args.docs_root)
-        if orphans:
-            print(f"\n🗄️  Archiving {len(orphans)} orphaned page(s)...")
-            for rel_path in orphans:
-                entry = state.get_page(rel_path)
-                if entry:
-                    success = archive_page(api, entry["page_id"], entry["title"])
-                    if success:
-                        state.remove_page(rel_path)
-                        state.save()
+        elif hasattr(args, "directory") and args.directory:
+            results, hierarchy_pages = deploy_tree(
+                api, space_id, args.directory, args.docs_root, git_repo_url
+            )
+            for h_rel_path, h_page_id, h_title in hierarchy_pages:
+                state.set_page(
+                    rel_path=h_rel_path,
+                    page_id=h_page_id,
+                    title=h_title,
+                    space_key=args.space,
+                    space_id=space_id,
+                    content_hash="",
+                )
+            for filepath, page_id in results:
+                if page_id:
+                    state.set_page(
+                        rel_path=_rel_path(filepath),
+                        page_id=page_id,
+                        title=_derive_title(filepath),
+                        space_key=args.space,
+                        space_id=space_id,
+                        content_hash=state.compute_hash(filepath),
+                    )
+            state.save()
+
+        # Archive orphaned pages
+        if getattr(args, "archive_orphans", False):
+            orphans = state.find_orphans(all_files, args.docs_root)
+            if orphans:
+                print(f"\nArchiving {len(orphans)} orphaned page(s)...")
+                archived_any = False
+                for rel_path in orphans:
+                    entry = state.get_page(rel_path)
+                    if entry:
+                        success = archive_page(api, entry["page_id"], entry["title"])
+                        if success:
+                            state.remove_page(rel_path)
+                            archived_any = True
+                if archived_any:
+                    # If save() throws here, in-memory state has orphans removed but
+                    # remote state has not been updated. Re-run --archive-orphans to
+                    # retry. The lock will be released normally by the outer finally.
+                    state.save()
+            else:
+                print("\nNo orphaned pages found.")
+
+        print("\nDeployment complete!")
+    finally:
+        lock_mgr.release()
+
+
+def _handle_state(args, parser):
+    """Handle the 'state' subcommand."""
+    if not hasattr(args, "state_command") or args.state_command is None:
+        print("Error: Specify a state subcommand: list, pull, push, rm, show")
+        sys.exit(1)
+
+    _require_credentials(args, parser)
+    api = _create_api(args)
+    space_id = api.get_space_id(args.space)
+    mgmt_page_id = _find_management_page(api, space_id)
+    backend = ConfluenceBackend(api, mgmt_page_id)
+    state = StateManager(backend)
+    state.load()
+
+    if args.state_command == "list":
+        pages = state.all_pages
+        if not pages:
+            print("No pages tracked in state.")
+            return
+        print(f"Tracked pages ({len(pages)}):\n")
+        for rel_path, entry in sorted(pages.items()):
+            print(f"  {rel_path}")
+            print(f"    page_id: {entry['page_id']}")
+            print(f"    title:   {entry['title']}")
+            print(f"    deployed: {entry.get('deployed_at', 'unknown')}")
+            print()
+
+    elif args.state_command == "pull":
+        print(json.dumps(state.raw_state, indent=2, sort_keys=True))
+
+    elif args.state_command == "push":
+        try:
+            raw = args.file.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Error reading '{args.file}': {e}")
+            sys.exit(1)
+        if (
+            not isinstance(data, dict)
+            or "version" not in data
+            or "pages" not in data
+            or not isinstance(data["pages"], dict)
+        ):
+            print("Error: invalid state file — must have 'version' key and 'pages' dict.")
+            sys.exit(1)
+        for path_key, entry in data["pages"].items():
+            pid = entry.get("page_id") if isinstance(entry, dict) else None
+            if not isinstance(pid, str) or not re.match(r"^[1-9]\d*$", pid):
+                display_key = "".join(c for c in path_key[:200] if c.isprintable())
+                print(
+                    f"Error: invalid state file — entry '{display_key}' has missing or "
+                    "invalid 'page_id' (must be a quoted positive integer string, "
+                    'e.g. "12345", with no leading zeros).'
+                )
+                sys.exit(1)
+        lock_mgr = LockManager(api, mgmt_page_id)
+        try:
+            lock_mgr.acquire(operation="state-push")
+        except LockError as e:
+            print(f"Error: cannot push state while locked: {e}")
+            sys.exit(1)
+        try:
+            print("Warning: this overwrites remote state. Use with caution.")
+            backend.save(data)
+            print(f"Remote state updated from '{args.file}'.")
+        finally:
+            lock_mgr.release()
+
+    elif args.state_command == "rm":
+        rel_path = args.path
+        entry = state.get_page(rel_path)
+        if entry is None:
+            print(f"Error: '{rel_path}' is not tracked in state.")
+            sys.exit(1)
+        lock_mgr = LockManager(api, mgmt_page_id)
+        try:
+            lock_mgr.acquire(operation="state-rm")
+        except LockError as e:
+            print(f"Error: cannot remove state entry while locked: {e}")
+            sys.exit(1)
+        try:
+            state.remove_page(rel_path)
+            state.save()
+            print(f"Removed '{rel_path}' from state.")
+        finally:
+            lock_mgr.release()
+
+    elif args.state_command == "show":
+        rel_path = args.path
+        entry = state.get_page(rel_path)
+        if entry is None:
+            print(f"Error: '{rel_path}' is not tracked in state.")
+            sys.exit(1)
+        print(json.dumps(entry, indent=2, sort_keys=True))
+
+
+def _handle_lock(args, parser):
+    """Handle the 'lock' subcommand."""
+    if not hasattr(args, "lock_command") or args.lock_command is None:
+        print("Error: Specify a lock subcommand: acquire, status, release")
+        sys.exit(1)
+
+    _require_credentials(args, parser)
+    api = _create_api(args)
+    space_id = api.get_space_id(args.space)
+    mgmt_page_id = _find_management_page(api, space_id)
+    lock_mgr = LockManager(api, mgmt_page_id)
+
+    if args.lock_command == "acquire":
+        try:
+            lock_id = getattr(args, "lock_id", None)
+            operation = getattr(args, "operation", "manual")
+            lock_mgr.acquire(operation=operation, lock_id=lock_id)
+            info = lock_mgr.status()
+            print(f"Lock acquired by {info.owner} (operation: {info.operation})")
+        except LockError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
+    elif args.lock_command == "status":
+        info = lock_mgr.status()
+        if not info.locked:
+            print("State is not locked.")
         else:
-            print("\nℹ️  No orphaned pages found.")
+            print("State is locked:")
+            print(f"  Owner:     {info.owner}")
+            if info.lock_id:
+                print(f"  Lock ID:   {info.lock_id}")
+            print(f"  Since:     {info.locked_at}")
+            print(f"  Operation: {info.operation}")
 
-    print("\n✨ Deployment complete!")
+    elif args.lock_command == "release":
+        lock_mgr.force_release()
+        print("Lock released.")
+
+
+def main():
+    """CLI entry point."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # Resolve config file
+    args = _resolve_config(args)
+
+    # Route to subcommand handler
+    if args.command == "init":
+        _handle_init(args, parser)
+    elif args.command == "deploy":
+        _handle_deploy(args, parser)
+    elif args.command == "state":
+        _handle_state(args, parser)
+    elif args.command == "lock":
+        _handle_lock(args, parser)
+    else:
+        parser.print_help()
+        sys.exit(1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/ccfm_convert/state/__init__.py
+++ b/src/ccfm_convert/state/__init__.py
@@ -1,5 +1,16 @@
 """State management for CCFM deployments."""
 
+from .backend import ConfluenceBackend, StateBackend
+from .init import init_remote_state
+from .lock import LockError, LockInfo, LockManager
 from .manager import StateManager
 
-__all__ = ["StateManager"]
+__all__ = [
+    "ConfluenceBackend",
+    "LockError",
+    "LockInfo",
+    "LockManager",
+    "StateBackend",
+    "StateManager",
+    "init_remote_state",
+]

--- a/src/ccfm_convert/state/backend.py
+++ b/src/ccfm_convert/state/backend.py
@@ -1,0 +1,65 @@
+"""State storage backends for CCFM deployments."""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from ccfm_convert.deploy.api import ConfluenceAPI
+
+STATE_VERSION = "1"
+
+
+class StateBackend(Protocol):
+    """Protocol for state storage backends.
+
+    Implementations must provide load() and save() for persisting state data.
+    The protocol exists for future extensibility (e.g. S3 backend).
+    """
+
+    def load(self) -> dict:
+        """Load state data. Returns empty state dict if no state exists."""
+        ...
+
+    def save(self, data: dict) -> None:
+        """Persist state data."""
+        ...
+
+
+def _empty_state() -> dict:
+    """Return a fresh empty state structure."""
+    return {"version": STATE_VERSION, "pages": {}}
+
+
+class ConfluenceBackend:
+    """Stores state as an attachment on the CCFM management page in Confluence."""
+
+    STATE_ATTACHMENT_NAME = "ccfm-state.json"
+
+    def __init__(self, api: "ConfluenceAPI", page_id: str) -> None:
+        self._api = api
+        self._page_id = page_id
+
+    def load(self) -> dict:
+        """Download state from the management page attachment."""
+        content = self._api.download_attachment(self._page_id, self.STATE_ATTACHMENT_NAME)
+        if content is None:
+            return _empty_state()
+        data = json.loads(content.decode("utf-8"))
+        if not isinstance(data, dict) or not isinstance(data.get("pages"), dict):
+            raise ValueError(
+                f"Remote state attachment has unexpected schema (page_id={self._page_id})"
+            )
+        return data
+
+    def save(self, data: dict) -> None:
+        """Upload state as a JSON attachment to the management page."""
+        payload = json.dumps(data, indent=2, sort_keys=True).encode("utf-8")
+        with tempfile.NamedTemporaryFile(suffix=".json", prefix="ccfm-state-", delete=False) as fh:
+            fh.write(payload)
+            tmp_path = Path(fh.name)
+        try:
+            self._api.upload_attachment(self._page_id, tmp_path, name=self.STATE_ATTACHMENT_NAME)
+        finally:
+            tmp_path.unlink(missing_ok=True)

--- a/src/ccfm_convert/state/init.py
+++ b/src/ccfm_convert/state/init.py
@@ -1,0 +1,84 @@
+"""Initialize CCFM remote state infrastructure in a Confluence space."""
+
+from ccfm_convert.deploy.api import ConfluenceAPI
+
+CONTAINER_PAGE_TITLE = "_ccfm"
+MANAGEMENT_PAGE_TITLE = "CCFM State Management"
+MANAGEMENT_PAGE_LABEL = "ccfm-internal"
+
+_MANAGEMENT_PAGE_ADF = {
+    "version": 1,
+    "type": "doc",
+    "content": [
+        {
+            "type": "panel",
+            "attrs": {"panelType": "info"},
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "This page is managed by ccfm-convert. "
+                            "It stores deployment state (ccfm-state.json attachment) "
+                            "and locking metadata (ccfm-lock property). "
+                            "Do not edit this page manually.",
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+def init_remote_state(api: ConfluenceAPI, space_key: str, space_id: str) -> str:
+    """Create the CCFM management infrastructure if it does not already exist.
+
+    Creates a ``_ccfm`` container page at the space root, then a
+    ``CCFM State Management`` child page with the ``ccfm-internal`` label.
+
+    The management page is discovered as a direct child of the ``_ccfm``
+    container (not by label search), so orphaned management pages left over
+    from failed cleanups are automatically ignored.
+
+    Returns:
+        The page ID of the management page (new or existing).
+    """
+    _CONTAINER_ADF = {
+        "version": 1,
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "CCFM internal management pages. Do not delete.",
+                    }
+                ],
+            }
+        ],
+    }
+
+    # Always ensure the _ccfm container page exists.
+    # Do this before checking for the management page so that a deleted container
+    # is always recreated, even when the management page survived as an orphan.
+    container_id = api.find_page_by_title(space_id, CONTAINER_PAGE_TITLE)
+    if container_id is None:
+        container_id = api.create_page(space_id, None, CONTAINER_PAGE_TITLE, _CONTAINER_ADF)
+        print(f"Created container page: {CONTAINER_PAGE_TITLE} (ID: {container_id})")
+
+    # Find management page as a direct child of the container (deterministic).
+    # Child-page lookup ignores orphaned management pages from failed cleanups —
+    # those pages are not under the container so they won't be returned here.
+    existing_id = api.find_child_page_by_title(container_id, MANAGEMENT_PAGE_TITLE)
+    if existing_id is not None:
+        print(f"Management page already exists (ID: {existing_id}).")
+        return existing_id
+
+    # Create management page under container
+    page_id = api.create_page(space_id, container_id, MANAGEMENT_PAGE_TITLE, _MANAGEMENT_PAGE_ADF)
+    api.add_labels(page_id, [MANAGEMENT_PAGE_LABEL])
+    print(f"Created management page: {MANAGEMENT_PAGE_TITLE} (ID: {page_id})")
+    return page_id

--- a/src/ccfm_convert/state/lock.py
+++ b/src/ccfm_convert/state/lock.py
@@ -1,0 +1,109 @@
+"""Terraform-style locking for CCFM remote state."""
+
+import os
+import socket
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import requests
+
+if TYPE_CHECKING:
+    from ccfm_convert.deploy.api import ConfluenceAPI
+
+LOCK_PROPERTY_KEY = "ccfm-lock"
+
+
+class LockError(Exception):
+    """Raised when a lock cannot be acquired."""
+
+
+@dataclass
+class LockInfo:
+    """Information about the current lock state."""
+
+    locked: bool
+    owner: str = ""
+    lock_id: str = ""
+    locked_at: str = ""
+    operation: str = ""
+    version: int | None = None
+
+
+def _default_owner() -> str:
+    """Return a default lock owner identifier: user@hostname."""
+    user = os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+    return f"{user}@{socket.gethostname()}"
+
+
+class LockManager:
+    """Manages distributed locking via Confluence content properties.
+
+    Uses optimistic concurrency: reads the property version, then writes with
+    that version. If another process modified the property between read and
+    write, Confluence returns 409 Conflict.
+    """
+
+    def __init__(self, api: "ConfluenceAPI", page_id: str) -> None:
+        self._api = api
+        self._page_id = page_id
+
+    def status(self) -> LockInfo:
+        """Return the current lock status."""
+        prop = self._api.get_content_property(self._page_id, LOCK_PROPERTY_KEY)
+        if prop is None:
+            return LockInfo(locked=False)
+        val = prop.get("value", {})
+        return LockInfo(
+            locked=val.get("locked", False),
+            owner=val.get("owner", ""),
+            lock_id=val.get("lock_id", ""),
+            locked_at=val.get("locked_at", ""),
+            operation=val.get("operation", ""),
+            version=prop.get("version", {}).get("number"),
+        )
+
+    def acquire(self, operation: str = "deploy", lock_id: str | None = None) -> None:
+        """Acquire the lock. Raises LockError if already held."""
+        info = self.status()
+        if info.locked:
+            raise LockError(
+                f"State is locked by {info.owner}"
+                + (f" (lock_id: {info.lock_id})" if info.lock_id else "")
+                + f" since {info.locked_at}"
+                + f" (operation: {info.operation})."
+                + " Run `ccfm lock release` to force-unlock."
+            )
+        owner = _default_owner()
+        value = {
+            "locked": True,
+            "owner": owner,
+            "lock_id": lock_id or "",
+            "locked_at": datetime.now(UTC).isoformat(),
+            "operation": operation,
+        }
+        try:
+            self._api.set_content_property(
+                self._page_id,
+                LOCK_PROPERTY_KEY,
+                value,
+                version=info.version + 1 if info.version is not None else None,
+            )
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 409:
+                raise LockError("Lock was acquired by another process (version conflict).") from exc
+            raise
+
+    def release(self) -> None:
+        """Release the lock. No-op if the property doesn't exist.
+
+        Confluence returns 403 (not 404) when DELETE is called on a content
+        property that has never been created, so we must guard with a GET first.
+        """
+        if self._api.get_content_property(self._page_id, LOCK_PROPERTY_KEY) is None:
+            return
+        self._api.delete_content_property(self._page_id, LOCK_PROPERTY_KEY)
+
+    def force_release(self) -> None:
+        """Force-release the lock regardless of owner."""
+        self.release()

--- a/src/ccfm_convert/state/manager.py
+++ b/src/ccfm_convert/state/manager.py
@@ -1,27 +1,25 @@
-"""CCFM state manager — persists filepath → page_id mappings between deployments."""
+"""CCFM state manager — persists filepath -> page_id mappings between deployments."""
 
+import copy
 import hashlib
-import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 
+from ccfm_convert.state.backend import StateBackend
+
 
 class StateManager:
-    """Tracks deployed pages across runs via a local JSON state file.
+    """Tracks deployed pages across runs via a remote state backend.
 
-    The state file maps relative file paths (from the working directory) to their
+    The state maps relative file paths (from the working directory) to their
     Confluence page metadata, enabling changed-files-only deployment, orphan detection,
     and plan/diff mode.
-
-    The state file is intended to be committed alongside documentation so that CI
-    pipelines and team members share the same deployment history.
     """
 
     STATE_VERSION = "1"
 
-    def __init__(self, path: Path):
-        self.path = path
+    def __init__(self, backend: StateBackend) -> None:
+        self._backend = backend
         self._state: dict = {"version": self.STATE_VERSION, "pages": {}}
 
     # ------------------------------------------------------------------
@@ -29,29 +27,12 @@ class StateManager:
     # ------------------------------------------------------------------
 
     def load(self) -> None:
-        """Load state from disk. Silent no-op if the file does not exist."""
-        if not self.path.exists():
-            return
-        with open(self.path, encoding="utf-8") as fh:
-            data = json.load(fh)
-        if not isinstance(data, dict) or not isinstance(data.get("pages"), dict):
-            raise ValueError(f"State file has unexpected schema: {self.path}")
-        self._state = data
+        """Load state from the backend."""
+        self._state = self._backend.load()
 
     def save(self) -> None:
-        """Atomically write state to disk (write-then-rename).
-
-        Creates parent directories if they do not exist. The temporary file is
-        written with mode 0o600 (owner read/write only) to avoid exposing space
-        IDs and page titles to other users on shared systems.
-        """
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(".json.tmp")
-        payload = json.dumps(self._state, indent=2, sort_keys=True)
-        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(payload)
-        tmp.rename(self.path)
+        """Persist state via the backend."""
+        self._backend.save(self._state)
 
     # ------------------------------------------------------------------
     # Page records
@@ -86,8 +67,17 @@ class StateManager:
 
     @property
     def all_pages(self) -> dict:
-        """Return a shallow copy of all page entries keyed by relative path."""
-        return dict(self._state["pages"])
+        """Return a deep copy of all page entries keyed by relative path."""
+        return copy.deepcopy(self._state["pages"])
+
+    @property
+    def raw_state(self) -> dict:
+        """Return a deep copy of the full state dict (version + pages).
+
+        A deep copy prevents callers from accidentally mutating internal state
+        through the returned pages dict.
+        """
+        return copy.deepcopy(self._state)
 
     # ------------------------------------------------------------------
     # Content hashing
@@ -139,6 +129,9 @@ class StateManager:
         current_rel = {_to_rel(f) for f in current_files}
         orphans = []
         for rel_path in self._state["pages"]:
+            # Skip directory container pages (no .md extension) — they are not files on disk
+            if not rel_path.endswith(".md"):
+                continue
             # Only flag orphans that were under the docs_root being deployed
             try:
                 Path(rel_path).relative_to(docs_root_rel)

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -10,7 +10,7 @@ Leave pages in Confluence for manual inspection (no cleanup):
 
     pytest tests/smoke/ --no-cov -v --no-cleanup
 
-Delete pages from a previous --no-cleanup run without re-running tests:
+Delete pages from a previous --no-cleanup run (skips re-running tests):
 
     pytest tests/smoke/ --no-cov -v --cleanup-only
 
@@ -23,7 +23,6 @@ Environment variables required
 Or: copy .env.smoke.example to .env, fill in values, then ``source .env``.
 """
 
-import json
 import os
 import subprocess
 import sys
@@ -37,7 +36,6 @@ import requests
 # ---------------------------------------------------------------------------
 
 SMOKE_DIR = Path(__file__).parent
-SMOKE_STATE = SMOKE_DIR / ".ccfm-smoke-state.json"
 SMOKE_DOCS = SMOKE_DIR / "docs"
 PROJECT_ROOT = SMOKE_DIR.parent.parent
 
@@ -63,7 +61,7 @@ def pytest_addoption(parser):
         default=False,
         help=(
             "Delete all pages from a previous smoke run without re-running tests. "
-            "Reads from the existing smoke state file."
+            "Cleans up the _ccfm management page and any deployed pages."
         ),
     )
 
@@ -84,66 +82,282 @@ def pytest_collection_modifyitems(config, items):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    """Delete all Confluence pages tracked in the smoke state file."""
+    """Delete deployed pages and the _ccfm management infrastructure."""
     try:
         no_cleanup = session.config.getoption("--no-cleanup", default=False)
     except ValueError:
         no_cleanup = False
 
     if no_cleanup:
-        print(
-            f"\n\nSmoke state preserved at: {SMOKE_STATE}"
-            "\nRun with --cleanup-only to delete pages later."
-        )
+        print("\n\nSmoke pages preserved in Confluence.")
+        print("Run with --cleanup-only to delete pages later.")
         return
 
     _delete_smoke_pages()
 
 
 def _delete_smoke_pages():
-    """Permanently delete all Confluence pages tracked in the smoke state file."""
-    if not SMOKE_STATE.exists():
-        return
+    """Delete deployed pages via remote state and reset state to empty.
 
-    try:
-        data = json.loads(SMOKE_STATE.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return
-
+    The _ccfm container and CCFM State Management page are preserved —
+    they are one-time infrastructure and should not be torn down between runs.
+    """
     domain = os.environ.get("CONFLUENCE_DOMAIN", "")
     email = os.environ.get("CONFLUENCE_EMAIL", "")
     token = os.environ.get("CONFLUENCE_TOKEN", "")
 
     if not (domain and email and token):
-        print("\nWarning: credentials not available for smoke cleanup — state file left in place.")
+        print("\nWarning: credentials not available for smoke cleanup.")
         return
 
     auth = (email, token)
-    pages = data.get("pages", {})
-    deleted = 0
-    failed = 0
+    space_key = SMOKE_SPACE
 
-    print(f"\n\nCleaning up {len(pages)} smoke test page(s)...")
-    for rel_path, entry in pages.items():
-        page_id = entry.get("page_id")
-        title = entry.get("title", rel_path)
-        if not page_id:
-            continue
-        url = f"https://{domain}/wiki/api/v2/pages/{page_id}"
-        try:
-            resp = requests.delete(url, auth=auth, timeout=15)
-            if resp.status_code in (200, 204, 404):
-                print(f"  ✓ Deleted: {title} (ID: {page_id})")
-                deleted += 1
-            else:
-                print(f"  ✗ Failed to delete: {title} ({resp.status_code})")
-                failed += 1
-        except requests.RequestException as e:
-            print(f"  ✗ Error deleting {title}: {e}")
-            failed += 1
+    # Step 1: Find space ID, container, and management page via container→child lookup.
+    space_id = _get_space_id(domain, auth, space_key)
+    if not space_id:
+        print("\nWarning: could not look up space ID — skipping cleanup.")
+        return
 
-    SMOKE_STATE.unlink(missing_ok=True)
-    print(f"Cleanup complete: {deleted} deleted, {failed} failed.")
+    container_id = _find_page_by_title_in_space(domain, auth, space_id, "_ccfm")
+    if not container_id:
+        print("\nNo _ccfm container found — nothing to clean up.")
+        return
+
+    mgmt_page_id = _find_child_by_title(domain, auth, container_id, "CCFM State Management")
+    if not mgmt_page_id:
+        print("\nNo CCFM State Management page found — skipping state cleanup.")
+    else:
+        # Step 2: Download remote state and delete all tracked pages
+        state_data = _download_state(domain, auth, mgmt_page_id)
+        if state_data:
+            pages = state_data.get("pages", {})
+            deleted = 0
+            failed = 0
+            print(f"\n\nCleaning up {len(pages)} smoke test page(s)...")
+            for rel_path, entry in pages.items():
+                page_id = entry.get("page_id")
+                title = entry.get("title", rel_path)
+                if not page_id:
+                    continue
+                url = f"https://{domain}/wiki/api/v2/pages/{page_id}"
+                try:
+                    resp = requests.delete(url, auth=auth, timeout=15)
+                    if resp.status_code in (200, 204, 404):
+                        print(f"  ✓ Deleted: {title} (ID: {page_id})")
+                        deleted += 1
+                    else:
+                        print(f"  ✗ Failed to delete: {title} ({resp.status_code})")
+                        failed += 1
+                except requests.RequestException as e:
+                    print(f"  ✗ Error deleting {title}: {e}")
+                    failed += 1
+            print(f"Pages cleanup: {deleted} deleted, {failed} failed.")
+
+        # Step 3: Reset state to empty — preserves the management page for next run.
+        _reset_state(domain, auth, mgmt_page_id)
+
+    # Step 4: Delete hierarchy pages not tracked in state (created by ensure_page_hierarchy).
+    # Must delete children before parent — Confluence v2 does not cascade-delete.
+    # Note: hierarchy pages are now tracked in state and deleted in step 2.
+    # This step handles any remaining hierarchy root pages not caught by state.
+    ccfm_example_id = _find_page_by_title_in_space(domain, auth, space_id, "CCFM Example")
+    if ccfm_example_id:
+        _delete_all_children(domain, auth, ccfm_example_id)
+        _delete_page(domain, auth, ccfm_example_id, '"CCFM Example"')
+
+    print("  ✓ _ccfm container and management page preserved for next run.")
+
+
+def _get_space_id(domain, auth, space_key):
+    """Return the numeric space ID for a space key, or None on failure."""
+    try:
+        resp = requests.get(
+            f"https://{domain}/wiki/api/v2/spaces",
+            params={"keys": space_key},
+            auth=auth,
+            headers={"Accept": "application/json"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        return results[0]["id"] if results else None
+    except requests.RequestException:
+        return None
+
+
+def _find_page_by_title_in_space(domain, auth, space_id, title):
+    """Find a page by exact title within a space using v2 API."""
+    try:
+        resp = requests.get(
+            f"https://{domain}/wiki/api/v2/pages",
+            params={"space-id": space_id, "title": title, "limit": 1},
+            auth=auth,
+            headers={"Accept": "application/json"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        return results[0]["id"] if results else None
+    except requests.RequestException:
+        return None
+
+
+def _find_child_by_title(domain, auth, parent_id, title):
+    """Find a direct child page of parent_id by exact title."""
+    try:
+        url = f"https://{domain}/wiki/api/v2/pages/{parent_id}/children"
+        params: dict = {"limit": 50}
+        while True:
+            resp = requests.get(
+                url, params=params, auth=auth, headers={"Accept": "application/json"}, timeout=15
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            for page in data.get("results", []):
+                if page.get("title") == title:
+                    return page["id"]
+            next_url = data.get("_links", {}).get("next")
+            if not next_url:
+                break
+            url = f"https://{domain}/wiki{next_url}"
+            params = {}
+        return None
+    except requests.RequestException:
+        return None
+
+
+def _delete_page(domain, auth, page_id, label="page"):
+    """Delete a page by ID. Accepts 404 as success."""
+    url = f"https://{domain}/wiki/api/v2/pages/{page_id}"
+    try:
+        resp = requests.delete(url, auth=auth, timeout=15)
+        if resp.status_code in (200, 204, 404):
+            print(f"  ✓ Deleted {label} (ID: {page_id})")
+        else:
+            print(f"  ✗ Failed to delete {label} ({resp.status_code})")
+    except requests.RequestException as e:
+        print(f"  ✗ Error deleting {label}: {e}")
+
+
+def _delete_page_by_title(domain, auth, space_id, title):
+    """Find a page by title and delete it."""
+    page_id = _find_page_by_title_in_space(domain, auth, space_id, title)
+    if page_id:
+        _delete_page(domain, auth, page_id, f'"{title}"')
+
+
+def _delete_all_children(domain, auth, parent_id):
+    """Recursively delete all descendants of parent_id.
+
+    Confluence v2 API does not cascade-delete children, so nested hierarchies
+    must be deleted bottom-up. This function recurses into each child before
+    deleting it, ensuring grandchildren are removed first.
+    """
+    try:
+        url = f"https://{domain}/wiki/api/v2/pages/{parent_id}/children"
+        params: dict = {"limit": 50}
+        children = []
+        while True:
+            resp = requests.get(
+                url,
+                params=params,
+                auth=auth,
+                headers={"Accept": "application/json"},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            children.extend(data.get("results", []))
+            if not data.get("_links", {}).get("next"):
+                break
+            url = f"https://{domain}/wiki{data['_links']['next']}"
+            params = {}
+        for page in children:
+            _delete_all_children(domain, auth, page["id"])
+            _delete_page(domain, auth, page["id"], f'"{page.get("title", page["id"])}"')
+    except requests.RequestException as e:
+        print(f"  ✗ Error listing children of {parent_id}: {e}")
+
+
+def _reset_state(domain, auth, mgmt_page_id):
+    """Upload an empty state JSON to the management page, resetting state for the next run.
+
+    Checks whether the ccfm-state.json attachment already exists:
+    - If yes, updates via POST .../attachment/{id}/data
+    - If no, creates via POST .../attachment
+    """
+    import io
+    import json
+
+    empty_state = json.dumps({"version": "1", "pages": {}}, indent=2).encode()
+    base_url = f"https://{domain}/wiki/rest/api/content/{mgmt_page_id}/child/attachment"
+    headers = {"X-Atlassian-Token": "nocheck"}
+
+    try:
+        # Check if the attachment already exists
+        resp = requests.get(
+            base_url,
+            params={"filename": "ccfm-state.json"},
+            auth=auth,
+            headers={"Accept": "application/json"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        existing = resp.json().get("results", [])
+        if existing:
+            upload_url = f"{base_url}/{existing[0]['id']}/data"
+        else:
+            upload_url = base_url
+
+        resp = requests.post(
+            upload_url,
+            files={"file": ("ccfm-state.json", io.BytesIO(empty_state), "application/json")},
+            headers=headers,
+            auth=auth,
+            timeout=30,
+        )
+        if resp.status_code in (200, 201):
+            print("  ✓ State reset to empty")
+        else:
+            print(f"  ✗ Failed to reset state ({resp.status_code})")
+    except requests.RequestException as e:
+        print(f"  ✗ Error resetting state: {e}")
+
+
+def _find_container_page(domain, auth, space_key):
+    """Find the _ccfm container page by title (kept for backward compatibility)."""
+    space_id = _get_space_id(domain, auth, space_key)
+    if not space_id:
+        return None
+    return _find_page_by_title_in_space(domain, auth, space_id, "_ccfm")
+
+
+def _download_state(domain, auth, mgmt_page_id):
+    """Download the ccfm-state.json attachment from the management page."""
+    import json
+
+    list_url = f"https://{domain}/wiki/rest/api/content/{mgmt_page_id}/child/attachment"
+    try:
+        resp = requests.get(
+            list_url,
+            params={"filename": "ccfm-state.json"},
+            auth=auth,
+            headers={"Accept": "application/json"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        if not results:
+            return None
+
+        download_path = results[0]["_links"]["download"]
+        download_url = f"https://{domain}/wiki{download_path}"
+        resp = requests.get(download_url, auth=auth, timeout=30)
+        resp.raise_for_status()
+        return json.loads(resp.content)
+    except (requests.RequestException, json.JSONDecodeError):
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -243,13 +457,13 @@ def confluence_live(smoke_creds):
 
 @pytest.fixture(scope="session")
 def ccfm_run(smoke_creds):
-    """Return a callable that invokes src/main.py with smoke credentials.
+    """Return a callable that invokes ccfm_convert with smoke credentials.
 
-    All invocations share the same state file (``SMOKE_STATE``) so page IDs
-    are preserved across test functions within the session.
+    Uses the subcommand CLI structure. The first positional arg should be
+    the subcommand (init, deploy, state, lock).
 
     Args:
-        *extra_args: Additional CLI arguments passed after the base credential flags.
+        *extra_args: CLI arguments including subcommand.
         check (bool): If True (default), raise CalledProcessError on non-zero exit.
 
     Returns:
@@ -269,8 +483,6 @@ def ccfm_run(smoke_creds):
             smoke_creds["token"],
             "--space",
             smoke_creds["space"],
-            "--state",
-            str(SMOKE_STATE),
             *extra_args,
         ]
         return subprocess.run(
@@ -284,10 +496,58 @@ def ccfm_run(smoke_creds):
     return _run
 
 
-@pytest.fixture(scope="session")
-def smoke_state():
-    """Return the path to the shared smoke state file."""
-    return SMOKE_STATE
+@pytest.fixture(scope="session", autouse=True)
+def _require_space_initialized(smoke_creds):
+    """Exit early if the CCFM space infrastructure has not been initialised.
+
+    The ``_ccfm`` container and ``CCFM State Management`` page are one-time
+    prerequisites — they must exist before any smoke test can run.  If they are
+    absent, the session exits immediately with a clear error message rather than
+    producing confusing test failures.
+
+    Run once manually to initialise:
+
+        ccfm init --domain <domain> --email <email> --token <token> --space <space>
+
+    See README.md → "Initial Setup" for full instructions.
+    """
+    domain = smoke_creds.get("domain", "")
+    email = smoke_creds.get("email", "")
+    token = smoke_creds.get("token", "")
+
+    if not (domain and email and token):
+        # Credentials missing — existing confluence_live fixture handles this per-test.
+        return
+
+    auth = (email, token)
+    space_key = smoke_creds["space"]
+
+    space_id = _get_space_id(domain, auth, space_key)
+    if not space_id:
+        return  # Network/credential issue — let individual tests fail with context.
+
+    container_id = _find_page_by_title_in_space(domain, auth, space_id, "_ccfm")
+    if not container_id:
+        pytest.exit(
+            f"\n\nCCFM space '{space_key}' is not initialised.\n"
+            "Run `ccfm init` to create the required management infrastructure:\n\n"
+            f"    ccfm --domain {domain} --email {email} "
+            "--token <token> --space " + space_key + " init\n\n"
+            "See README.md → 'Initial Setup' for full instructions.\n",
+            returncode=1,
+        )
+
+    mgmt_page_id = _find_child_by_title(domain, auth, container_id, "CCFM State Management")
+    if not mgmt_page_id:
+        pytest.exit(
+            f"\n\nCCFM space '{space_key}' is partially initialised "
+            "(_ccfm container found but CCFM State Management page is missing).\n"
+            "Re-run `ccfm init` to repair the infrastructure:\n\n"
+            f"    ccfm --domain {domain} --email {email} "
+            "--token <token> --space " + space_key + " init\n\n"
+            "See README.md → 'Initial Setup' for full instructions.\n",
+            returncode=1,
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/smoke/test_config_file.py
+++ b/tests/smoke/test_config_file.py
@@ -1,10 +1,11 @@
 """Smoke tests: deployment via --config ccfm.yaml with ${ENV_VAR} interpolation."""
 
-import json
+import subprocess
+import sys
 
 import pytest
 
-from tests.smoke.conftest import SMOKE_DIR, SMOKE_DOCS, SMOKE_STATE
+from tests.smoke.conftest import PROJECT_ROOT, SMOKE_DIR, SMOKE_DOCS
 
 pytestmark = pytest.mark.smoke
 
@@ -15,18 +16,8 @@ CONFIG_PAGE = SMOKE_DOCS / "config-test" / "config-page.md"
 class TestConfigFileDeploy:
     """Deploy using a ccfm.yaml config file instead of inline CLI flags."""
 
-    def test_deploy_via_config_file(self, confluence_live, smoke_state):
-        """--config ccfm.yaml with ${ENV_VAR} interpolation deploys successfully.
-
-        Relies on confluence_live to validate Confluence credentials before running
-        the subprocess — ensures the test skips cleanly when credentials are
-        missing or contain placeholder values from .env.smoke.example.
-        """
-        import subprocess
-        import sys
-
-        from tests.smoke.conftest import PROJECT_ROOT
-
+    def test_deploy_via_config_file(self, confluence_live):
+        """--config ccfm.yaml with ${ENV_VAR} interpolation deploys successfully."""
         result = subprocess.run(
             [
                 sys.executable,
@@ -34,10 +25,9 @@ class TestConfigFileDeploy:
                 "ccfm_convert",
                 "--config",
                 str(CONFIG_FILE),
+                "deploy",
                 "--file",
                 str(CONFIG_PAGE),
-                "--state",
-                str(SMOKE_STATE),
             ],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -48,11 +38,3 @@ class TestConfigFileDeploy:
         assert (
             "Success" in result.stdout or "Updating" in result.stdout or "Creating" in result.stdout
         ), f"Unexpected output:\n{result.stdout}"
-
-        assert smoke_state.exists(), "State file was not created after config-file deploy"
-        data = json.loads(smoke_state.read_text())
-        pages = data.get("pages", {})
-
-        matching = [v for k, v in pages.items() if "config-page.md" in k]
-        assert matching, f"config-page.md not found in state. State: {list(pages.keys())}"
-        assert matching[0]["page_id"], "page_id is empty for config-page"

--- a/tests/smoke/test_directory_deploy.py
+++ b/tests/smoke/test_directory_deploy.py
@@ -1,7 +1,5 @@
 """Smoke tests: directory deployment via --directory."""
 
-import json
-
 import pytest
 
 from tests.smoke.conftest import SMOKE_DOCS
@@ -10,38 +8,21 @@ pytestmark = pytest.mark.smoke
 
 EXAMPLE_DIR = SMOKE_DOCS / "example"
 
-# The three markdown files inside the example tree
-EXAMPLE_MD_FILES = [
-    "CCFM Example/complete_example.md",
-    "CCFM Example/My App/my_app.md",
-    "CCFM Example/My Team/my_team.md",
-]
-
 
 class TestDirectoryDeploy:
-    """Deploy an entire directory tree and verify all pages appear in state."""
+    """Deploy an entire directory tree and verify all pages deploy successfully."""
 
-    def test_tree_creates_all_pages(self, ccfm_run, smoke_state, confluence_live):
-        """--directory deploys all markdown files; state tracks each page_id."""
-        result = ccfm_run("--directory", str(EXAMPLE_DIR))
+    def test_tree_creates_all_pages(self, ccfm_run, confluence_live):
+        """deploy --directory deploys all markdown files."""
+        result = ccfm_run("deploy", "--directory", str(EXAMPLE_DIR))
 
         assert result.returncode == 0, f"Directory deploy failed:\n{result.stderr}"
-        assert smoke_state.exists(), "State file was not created after directory deploy"
+        # Should mention creating or updating pages
+        assert "Creating" in result.stdout or "Updating" in result.stdout
 
-        data = json.loads(smoke_state.read_text())
-        pages = data.get("pages", {})
-
-        for rel in EXAMPLE_MD_FILES:
-            # State keys contain the path relative to project root
-            matching = [v for k, v in pages.items() if rel in k]
-            assert matching, f"{rel} not found in state. State keys: {list(pages.keys())}"
-            assert matching[0]["page_id"], f"page_id is empty for {rel}"
-
-    def test_plan_shows_no_ops_after_deploy(self, ccfm_run, smoke_state, confluence_live):
-        """--plan after a full deploy reports NO-OP for all pages and exits 0."""
-        assert smoke_state.exists(), "State must exist from test_tree_creates_all_pages"
-
-        result = ccfm_run("--plan", "--directory", str(EXAMPLE_DIR), check=False)
+    def test_plan_shows_no_ops_after_deploy(self, ccfm_run, confluence_live):
+        """deploy --plan after a full deploy reports NO-OP for all pages and exits 0."""
+        result = ccfm_run("deploy", "--plan", "--directory", str(EXAMPLE_DIR), check=False)
 
         assert result.returncode == 0, (
             f"--plan after deploy should exit 0 (all NO-OP), got {result.returncode}.\n"

--- a/tests/smoke/test_remote_state.py
+++ b/tests/smoke/test_remote_state.py
@@ -1,0 +1,114 @@
+"""Smoke tests: remote state initialisation, locking, and state commands."""
+
+import pytest
+
+from tests.smoke.conftest import SMOKE_DOCS
+
+pytestmark = pytest.mark.smoke
+
+SINGLE_PAGE = SMOKE_DOCS / "single-page" / "single-page.md"
+
+
+class TestInit:
+    """ccfm init creates the _ccfm management infrastructure."""
+
+    def test_init_creates_management_page(self, ccfm_run, confluence_live):
+        """ccfm init creates _ccfm container and management page."""
+        result = ccfm_run("init")
+
+        assert result.returncode == 0, f"Init failed:\n{result.stderr}"
+        assert (
+            "Initialised" in result.stdout
+            or "already initialised" in result.stdout
+            or "Management page" in result.stdout
+        ), f"Unexpected init output:\n{result.stdout}"
+
+    def test_init_is_idempotent(self, ccfm_run, confluence_live):
+        """Running ccfm init again is a no-op."""
+        # First init
+        ccfm_run("init")
+
+        # Second init should succeed without error
+        result = ccfm_run("init")
+        assert result.returncode == 0, f"Idempotent init failed:\n{result.stderr}"
+
+
+class TestLocking:
+    """Deploy acquires/releases lock automatically; lock commands work."""
+
+    def test_lock_status_shows_unlocked(self, ccfm_run, confluence_live):
+        """ccfm lock status shows unlocked when no deploy is running."""
+        result = ccfm_run("lock", "status")
+
+        assert result.returncode == 0, f"Lock status failed:\n{result.stderr}"
+        assert (
+            "unlocked" in result.stdout.lower() or "not locked" in result.stdout.lower()
+        ), f"Expected unlocked status.\nstdout: {result.stdout}"
+
+    def test_deploy_acquires_and_releases_lock(self, ccfm_run, confluence_live):
+        """After a deploy completes, the lock is released."""
+        # Deploy a page
+        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+        assert result.returncode == 0, f"Deploy failed:\n{result.stderr}"
+
+        # Lock should be released after deploy
+        result = ccfm_run("lock", "status")
+        assert result.returncode == 0
+        assert (
+            "unlocked" in result.stdout.lower() or "not locked" in result.stdout.lower()
+        ), f"Lock should be released after deploy.\nstdout: {result.stdout}"
+
+    def test_force_release_is_idempotent(self, ccfm_run, confluence_live):
+        """lock release succeeds whether locked or unlocked (idempotent).
+
+        Uses check=False so we capture the returncode and get a meaningful
+        assertion error if it fails, rather than an unhandled CalledProcessError.
+        Calls release twice: once to clear any state, once to confirm idempotency.
+        """
+        # First call — may or may not have an existing lock, should always succeed
+        result = ccfm_run("lock", "release", check=False)
+        assert result.returncode == 0, f"First lock release failed:\n{result.stderr}"
+
+        # Second call — lock is definitely gone now; must still exit 0 (idempotent)
+        result = ccfm_run("lock", "release", check=False)
+        assert result.returncode == 0, f"Second lock release failed (idempotency):\n{result.stderr}"
+
+
+class TestStateCommands:
+    """ccfm state list and ccfm state rm commands."""
+
+    def test_state_list_shows_deployed_pages(self, ccfm_run, confluence_live):
+        """ccfm state list shows pages after a deploy."""
+        ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+
+        result = ccfm_run("state", "list")
+
+        assert result.returncode == 0, f"State list failed:\n{result.stderr}"
+        assert (
+            "single-page" in result.stdout
+        ), f"Expected single-page in state list.\nstdout: {result.stdout}"
+
+    def test_state_rm_removes_entry(self, ccfm_run, confluence_live):
+        """ccfm state rm removes a page entry from remote state."""
+        ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+
+        # Find the state key by listing
+        list_result = ccfm_run("state", "list")
+        # Extract a path that contains single-page
+        lines = list_result.stdout.strip().split("\n")
+        state_key = None
+        for line in lines:
+            if "single-page" in line:
+                # The state key is typically the first column or the path
+                state_key = line.strip().split()[0] if line.strip() else None
+                break
+
+        if state_key:
+            result = ccfm_run("state", "rm", state_key)
+            assert result.returncode == 0, f"State rm failed:\n{result.stderr}"
+
+            # Verify it's removed
+            list_after = ccfm_run("state", "list")
+            assert state_key not in list_after.stdout, (
+                f"State key {state_key} still present after rm.\n" f"stdout: {list_after.stdout}"
+            )

--- a/tests/smoke/test_single_file.py
+++ b/tests/smoke/test_single_file.py
@@ -1,7 +1,5 @@
 """Smoke tests: single-file deployment via --file."""
 
-import json
-
 import pytest
 
 from tests.smoke.conftest import SMOKE_DOCS
@@ -12,63 +10,35 @@ SINGLE_PAGE = SMOKE_DOCS / "single-page" / "single-page.md"
 
 
 class TestSingleFileDeploy:
-    """Deploy a single markdown file and verify state tracking."""
+    """Deploy a single markdown file and verify it deploys successfully."""
 
-    def test_page_created(self, ccfm_run, smoke_state, confluence_live):
-        """--file deploys successfully and state file records the page_id."""
-        result = ccfm_run("--file", str(SINGLE_PAGE))
+    def test_page_created(self, ccfm_run, confluence_live):
+        """deploy --file deploys successfully."""
+        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE))
 
         assert result.returncode == 0, f"Deploy failed:\n{result.stderr}"
         assert (
             "Success" in result.stdout or "Updating" in result.stdout or "Creating" in result.stdout
         )
 
-        assert smoke_state.exists(), "State file was not created after deploy"
-        data = json.loads(smoke_state.read_text())
-        pages = data.get("pages", {})
+    def test_page_updated_on_redeploy(self, ccfm_run, confluence_live):
+        """Re-deploying the same file updates (not duplicates) the page."""
+        # First deploy
+        ccfm_run("deploy", "--file", str(SINGLE_PAGE))
 
-        # State key is relative to project root
-        matching = [v for k, v in pages.items() if "single-page.md" in k]
-        assert matching, f"single-page.md not found in state. State: {list(pages.keys())}"
-        assert matching[0]["page_id"], "page_id is empty in state"
-
-    def test_page_updated_on_redeploy(self, ccfm_run, smoke_state, confluence_live):
-        """Re-deploying the same file updates (not duplicates) the page — same page_id."""
-        assert smoke_state.exists(), "State must exist from test_page_created"
-        data_before = json.loads(smoke_state.read_text())
-        page_id_before = next(
-            v["page_id"] for k, v in data_before["pages"].items() if "single-page.md" in k
-        )
-
-        result = ccfm_run("--file", str(SINGLE_PAGE))
+        # Second deploy should update
+        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE))
         assert result.returncode == 0
-
-        data_after = json.loads(smoke_state.read_text())
-        page_id_after = next(
-            v["page_id"] for k, v in data_after["pages"].items() if "single-page.md" in k
-        )
-
-        assert page_id_before == page_id_after, (
-            f"page_id changed between deploys: {page_id_before} → {page_id_after}. "
-            "This indicates a duplicate page was created instead of updated."
-        )
         assert "Updating" in result.stdout, "Expected 'Updating' in output for a re-deploy"
 
-    def test_dump_mode_writes_adf_no_state_change(self, ccfm_run, smoke_state):
-        """--dump writes an .adf.json file locally and does not modify the state file."""
+    def test_dump_mode_writes_adf(self, ccfm_run):
+        """deploy --dump writes an .adf.json file locally without API calls."""
         adf_file = SINGLE_PAGE.with_suffix(".adf.json")
         adf_file.unlink(missing_ok=True)
 
-        state_before = smoke_state.read_text() if smoke_state.exists() else None
-
-        result = ccfm_run("--file", str(SINGLE_PAGE), "--dump")
+        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE), "--dump")
         assert result.returncode == 0
         assert adf_file.exists(), ".adf.json file was not written by --dump"
-
-        state_after = smoke_state.read_text() if smoke_state.exists() else None
-        assert (
-            state_before == state_after
-        ), "State file was modified during --dump (it should not be)"
 
         # Cleanup the generated file
         adf_file.unlink(missing_ok=True)

--- a/tests/smoke/test_state_management.py
+++ b/tests/smoke/test_state_management.py
@@ -1,10 +1,8 @@
 """Smoke tests: state management — plan mode, --changed-only, --archive-orphans."""
 
-import json
-
 import pytest
 
-from tests.smoke.conftest import SMOKE_DOCS, SMOKE_STATE
+from tests.smoke.conftest import SMOKE_DOCS
 
 pytestmark = pytest.mark.smoke
 
@@ -20,12 +18,11 @@ BETA_KEY = "page-beta.md"
 class TestPlanMode:
     """--plan exit codes and output before/after a deploy."""
 
-    def test_plan_before_deploy_shows_creates(self, ccfm_run):
-        """--plan --plan-exit-code before any deploy exits 2 and lists CREATE actions."""
-        # Ensure no pre-existing state for this directory
-        SMOKE_STATE.unlink(missing_ok=True)
-
-        result = ccfm_run("--plan", "--plan-exit-code", "--directory", str(STATE_DIR), check=False)
+    def test_plan_before_deploy_shows_creates(self, ccfm_run, confluence_live):
+        """deploy --plan --plan-exit-code before any deploy exits 2 and lists CREATE actions."""
+        result = ccfm_run(
+            "deploy", "--plan", "--plan-exit-code", "--directory", str(STATE_DIR), check=False
+        )
 
         assert result.returncode == 2, (
             f"Expected exit 2 (pending changes) before first deploy, "
@@ -36,12 +33,12 @@ class TestPlanMode:
         ), f"Expected 'CREATE' in --plan output before deploy.\nstdout: {result.stdout}"
 
     def test_plan_after_deploy_shows_no_ops(self, ccfm_run, confluence_live):
-        """--plan after a full deploy exits 0 and shows NO-OP for all pages."""
+        """deploy --plan after a full deploy exits 0 and shows NO-OP for all pages."""
         # Deploy both pages first
-        result = ccfm_run("--directory", str(STATE_DIR))
+        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
         assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
 
-        result = ccfm_run("--plan", "--directory", str(STATE_DIR), check=False)
+        result = ccfm_run("deploy", "--plan", "--directory", str(STATE_DIR), check=False)
 
         assert result.returncode == 0, (
             f"Expected exit 0 (all NO-OP) after deploy, got {result.returncode}.\n"
@@ -57,10 +54,10 @@ class TestChangedOnly:
 
     def test_changed_only_skips_unchanged(self, ccfm_run, confluence_live):
         """After a clean deploy, --changed-only reports 0 files with changes."""
-        # Ensure both pages are deployed (may already be from TestPlanMode)
-        ccfm_run("--directory", str(STATE_DIR))
+        # Ensure both pages are deployed
+        ccfm_run("deploy", "--directory", str(STATE_DIR))
 
-        result = ccfm_run("--changed-only", "--directory", str(STATE_DIR))
+        result = ccfm_run("deploy", "--changed-only", "--directory", str(STATE_DIR))
 
         assert result.returncode == 0, f"--changed-only failed:\n{result.stderr}"
         assert (
@@ -70,7 +67,7 @@ class TestChangedOnly:
     def test_changed_only_deploys_modified_file(self, ccfm_run, tmp_path, confluence_live):
         """After modifying page-alpha, --changed-only deploys only that file."""
         # Ensure a clean baseline deploy first
-        ccfm_run("--directory", str(STATE_DIR))
+        ccfm_run("deploy", "--directory", str(STATE_DIR))
 
         # Write a modified copy of page-alpha with new content
         original_content = PAGE_ALPHA.read_text(encoding="utf-8")
@@ -82,7 +79,7 @@ class TestChangedOnly:
         try:
             PAGE_ALPHA.write_text(modified_content, encoding="utf-8")
 
-            result = ccfm_run("--changed-only", "--directory", str(STATE_DIR))
+            result = ccfm_run("deploy", "--changed-only", "--directory", str(STATE_DIR))
 
             assert (
                 result.returncode == 0
@@ -107,21 +104,14 @@ class TestChangedOnlyWithArchiveOrphans:
     """
 
     def test_noop_run_does_not_archive_any_pages(self, ccfm_run, confluence_live):
-        """Second deploy with --changed-only --archive-orphans must not archive anything.
-
-        Reproduces issue #3: run --changed-only --archive-orphans when no files
-        have changed since the previous deploy. All pages must remain deployed.
-        """
-        # Step 1: clean deploy — ensures both pages exist in Confluence and state
-        result = ccfm_run("--directory", str(STATE_DIR))
+        """Second deploy with --changed-only --archive-orphans must not archive anything."""
+        # Step 1: clean deploy
+        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
         assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
-
-        data_before = json.loads(SMOKE_STATE.read_text())
-        pages_before = set(data_before["pages"].keys())
-        assert pages_before, "State is empty after initial deploy"
 
         # Step 2: re-run with both flags — no files have changed, must be a no-op
         result = ccfm_run(
+            "deploy",
             "--changed-only",
             "--archive-orphans",
             "--directory",
@@ -134,31 +124,13 @@ class TestChangedOnlyWithArchiveOrphans:
             "No changes to deploy" in result.stdout
         ), f"Expected early-exit message when 0 changes detected.\nstdout: {result.stdout}"
 
-        # All pages tracked before must still be in state
-        data_after = json.loads(SMOKE_STATE.read_text())
-        pages_after = set(data_after["pages"].keys())
-        archived = pages_before - pages_after
-        assert not archived, (
-            f"Pages were incorrectly archived during a no-op run: {archived}\n"
-            f"stdout: {result.stdout}"
-        )
-
     def test_unchanged_files_not_treated_as_orphans(self, ccfm_run, confluence_live):
-        """When only one file changes, unchanged files on disk must not be archived.
-
-        Reproduces issue #3 (Bug 2): orphan detection must use all current disk
-        files, not just the --changed-only subset.
-        """
+        """When only one file changes, unchanged files on disk must not be archived."""
         # Step 1: clean baseline deploy
-        result = ccfm_run("--directory", str(STATE_DIR))
+        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
         assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
 
-        data_before = json.loads(SMOKE_STATE.read_text())
-        beta_entries = [k for k in data_before["pages"] if BETA_KEY in k]
-        assert beta_entries, "page-beta not in state after deploy"
-
-        # Step 2: modify page-alpha only → --changed-only will deploy it, but
-        # page-beta is unchanged on disk and must not be treated as an orphan
+        # Step 2: modify page-alpha only
         original_content = PAGE_ALPHA.read_text(encoding="utf-8")
         modified_content = original_content.replace(
             "Version: **1**",
@@ -168,6 +140,7 @@ class TestChangedOnlyWithArchiveOrphans:
             PAGE_ALPHA.write_text(modified_content, encoding="utf-8")
 
             result = ccfm_run(
+                "deploy",
                 "--changed-only",
                 "--archive-orphans",
                 "--directory",
@@ -179,14 +152,6 @@ class TestChangedOnlyWithArchiveOrphans:
                 result.returncode == 0
             ), f"--changed-only --archive-orphans failed:\n{result.stderr}"
 
-            # page-beta must still be in state — it's on disk, not an orphan
-            data_after = json.loads(SMOKE_STATE.read_text())
-            beta_still_present = [k for k in data_after["pages"] if BETA_KEY in k]
-            assert beta_still_present, (
-                f"page-beta was incorrectly archived as an orphan.\n"
-                f"State after: {list(data_after['pages'].keys())}\n"
-                f"stdout: {result.stdout}"
-            )
         finally:
             PAGE_ALPHA.write_text(original_content, encoding="utf-8")
 
@@ -200,17 +165,8 @@ class TestArchiveOrphans:
         The beta page should be archived and removed from state.
         """
         # Step 1: Deploy both pages to ensure beta is tracked
-        result = ccfm_run("--directory", str(STATE_DIR))
+        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
         assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
-
-        data = json.loads(SMOKE_STATE.read_text())
-        beta_entries = [k for k in data["pages"] if BETA_KEY in k]
-        assert (
-            beta_entries
-        ), f"page-beta.md not in state before archive test. State: {list(data['pages'].keys())}"
-
-        beta_page_id = data["pages"][beta_entries[0]]["page_id"]
-        assert beta_page_id, "page-beta page_id is empty"
 
         # Step 2: Temporarily move page-beta out of the directory so it becomes an orphan
         beta_backup = PAGE_BETA.with_suffix(".md.bak")
@@ -218,6 +174,7 @@ class TestArchiveOrphans:
 
         try:
             result = ccfm_run(
+                "deploy",
                 "--archive-orphans",
                 "--directory",
                 str(STATE_DIR),
@@ -226,20 +183,6 @@ class TestArchiveOrphans:
             )
 
             assert result.returncode == 0, f"--archive-orphans failed:\n{result.stderr}"
-
-            # beta should be archived and its state entry removed (or marked archived)
-            data_after = json.loads(SMOKE_STATE.read_text())
-            pages_after = data_after.get("pages", {})
-
-            beta_still_active = [
-                k
-                for k, v in pages_after.items()
-                if BETA_KEY in k and v.get("page_id") == beta_page_id
-            ]
-            assert not beta_still_active, (
-                f"page-beta is still active in state after --archive-orphans.\n"
-                f"State: {pages_after}"
-            )
 
         finally:
             # Restore page-beta so subsequent tests/cleanup can find it

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ class TestAPIInitialization:
 class TestGetSpaceId:
     """Test space ID retrieval."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_get_space_id_success(self, mock_get, api):
         """Test successful space ID retrieval."""
         mock_response = Mock()
@@ -45,7 +45,7 @@ class TestGetSpaceId:
         assert space_id == "123456"
         mock_get.assert_called_once()
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_get_space_id_not_found(self, mock_get, api):
         """Test space not found."""
         mock_response = Mock()
@@ -60,7 +60,7 @@ class TestGetSpaceId:
 class TestFindPageByTitle:
     """Test page lookup by title."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_find_page_found(self, mock_get, api):
         """Test finding existing page."""
         mock_response = Mock()
@@ -72,7 +72,7 @@ class TestFindPageByTitle:
 
         assert page_id == "789"
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_find_page_not_found(self, mock_get, api):
         """Test page not found."""
         mock_response = Mock()
@@ -84,7 +84,7 @@ class TestFindPageByTitle:
 
         assert page_id is None
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_find_page_http_error(self, mock_get, api):
         """Test HTTP error handling."""
         mock_response = Mock()
@@ -98,7 +98,7 @@ class TestFindPageByTitle:
 class TestCreatePage:
     """Test page creation."""
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_create_page_success(self, mock_post, api):
         """Test successful page creation."""
         mock_response = Mock()
@@ -112,7 +112,7 @@ class TestCreatePage:
         assert page_id == "999"
         mock_post.assert_called_once()
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_create_page_with_parent(self, mock_post, api):
         """Test page creation with parent."""
         mock_response = Mock()
@@ -129,7 +129,7 @@ class TestCreatePage:
         request_data = call_args[1]["json"]
         assert request_data["parentId"] == "456"
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_create_page_draft(self, mock_post, api):
         """Test creating draft page."""
         mock_response = Mock()
@@ -149,8 +149,8 @@ class TestCreatePage:
 class TestUpdatePage:
     """Test page updates."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.put")
+    @patch("requests.Session.get")
+    @patch("requests.Session.put")
     def test_update_page_success(self, mock_put, mock_get, api):
         """Test successful page update."""
         # Mock GET for current version
@@ -170,8 +170,8 @@ class TestUpdatePage:
         mock_get.assert_called_once()
         mock_put.assert_called_once()
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.put")
+    @patch("requests.Session.get")
+    @patch("requests.Session.put")
     def test_update_page_increments_version(self, mock_put, mock_get, api):
         """Test that version is incremented."""
         mock_get_response = Mock()
@@ -195,7 +195,7 @@ class TestUpdatePage:
 class TestAddLabels:
     """Test label management."""
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_add_labels_success(self, mock_post, api):
         """Test adding labels."""
         mock_response = Mock()
@@ -207,7 +207,7 @@ class TestAddLabels:
         # FIX: API may batch labels or call individually - check it was called
         assert mock_post.call_count >= 1
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_add_empty_labels(self, mock_post, api):
         """Test adding empty label list."""
         api.add_labels("789", [])
@@ -215,7 +215,7 @@ class TestAddLabels:
         # Should not make any calls
         mock_post.assert_not_called()
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_add_labels_with_existing(self, mock_post, api):
         """Test adding labels when some already exist."""
         # API may batch or call individually
@@ -232,8 +232,8 @@ class TestAddLabels:
 class TestUploadAttachment:
     """Test attachment uploads."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
     @patch("builtins.open", new_callable=mock_open, read_data=b"file content")
     def test_upload_new_attachment(self, mock_file, mock_post, mock_get, api):
         """Test uploading new attachment."""
@@ -255,8 +255,8 @@ class TestUploadAttachment:
         assert result is not None
         assert result["results"][0]["id"] == "att123"
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
     @patch("builtins.open", new_callable=mock_open, read_data=b"file content")
     def test_update_existing_attachment(self, mock_file, mock_post, mock_get, api):
         """Test updating existing attachment."""
@@ -277,8 +277,8 @@ class TestUploadAttachment:
 
         assert result is not None
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
     @patch("builtins.open", new_callable=mock_open, read_data=b"file content")
     def test_upload_attachment_failure(self, mock_file, mock_post, mock_get, api):
         """Test attachment upload failure."""
@@ -301,7 +301,7 @@ class TestUploadAttachment:
 class TestGetAttachmentFileId:
     """Test fetching attachment fileId."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_get_fileid_success(self, mock_get, api):
         """Test successful fileId retrieval."""
         mock_response = Mock()
@@ -317,7 +317,7 @@ class TestGetAttachmentFileId:
 
         assert file_id == "uuid-abc-123-def"
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_get_fileid_not_found(self, mock_get, api):
         """Test fileId not found."""
         mock_response = Mock()
@@ -328,7 +328,7 @@ class TestGetAttachmentFileId:
 
         assert file_id is None
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_get_fileid_no_fileid_field(self, mock_get, api):
         """Test response without fileId field."""
         mock_response = Mock()
@@ -348,7 +348,7 @@ class TestGetAttachmentFileId:
 class TestFindPageWebuiUrl:
     """Test find_page_webui_url (lines 65-78)."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_find_page_webui_url_found(self, mock_get, api):
         """Returns full https URL when page is found with _links.webui."""
         mock_response = Mock()
@@ -367,7 +367,7 @@ class TestFindPageWebuiUrl:
 
         assert url == "https://example.atlassian.net/wiki/spaces/KEY/pages/123/My+Page"
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_find_page_webui_url_not_found_returns_none(self, mock_get, api):
         """Returns None when no results are returned."""
         mock_response = Mock()
@@ -379,7 +379,7 @@ class TestFindPageWebuiUrl:
 
         assert url is None
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_find_page_webui_url_missing_webui_link_returns_none(self, mock_get, api):
         """Returns None when result has no _links.webui."""
         mock_response = Mock()
@@ -395,7 +395,7 @@ class TestFindPageWebuiUrl:
 class TestDeletePage:
     """Tests for delete_page (v2 DELETE endpoint)."""
 
-    @patch("ccfm_convert.deploy.api.requests.delete")
+    @patch("requests.Session.delete")
     def test_delete_page_success(self, mock_delete, api):
         """delete_page calls DELETE /pages/{id} and does not raise on success."""
         mock_response = Mock()
@@ -413,7 +413,7 @@ class TestDeletePage:
         )
         mock_response.raise_for_status.assert_called_once()
 
-    @patch("ccfm_convert.deploy.api.requests.delete")
+    @patch("requests.Session.delete")
     def test_delete_page_raises_on_http_error(self, mock_delete, api):
         """delete_page propagates HTTP errors from raise_for_status."""
         mock_response = Mock()
@@ -427,7 +427,7 @@ class TestDeletePage:
 class TestCreatePageErrorPath:
     """Test create_page error-printing branch (lines 105-111)."""
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_create_page_prints_error_detail_on_failure(self, mock_post, api):
         """When response is not ok, error details are printed and raise_for_status re-raises."""
         mock_response = Mock()
@@ -442,7 +442,7 @@ class TestCreatePageErrorPath:
         with pytest.raises(Exception, match="400 Bad Request"):
             api.create_page("space-123", None, "Test Page", body)
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_create_page_error_with_non_json_response(self, mock_post, api):
         """When error response body is not valid JSON, the inner exception is silently swallowed."""
         mock_response = Mock()
@@ -461,7 +461,7 @@ class TestCreatePageErrorPath:
 class TestAddLabelsWarning:
     """Test add_labels status-code warning branch (line 175)."""
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_add_labels_unexpected_status_prints_warning(self, mock_post, api):
         """When status code is not 200 or 400, a warning is printed."""
         mock_response = Mock()
@@ -478,8 +478,8 @@ class TestAddLabelsWarning:
 class TestUploadAttachmentNormalisation:
     """Test upload_attachment response normalisation (lines 248-249)."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
     @patch(
         "builtins.open",
         new_callable=__import__("unittest.mock", fromlist=["mock_open"]).mock_open,
@@ -512,8 +512,8 @@ class TestUploadAttachmentNormalisation:
         assert "results" in result
         assert result["results"][0]["id"] == "att456"
 
-    @patch("ccfm_convert.deploy.api.requests.get")
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
     @patch(
         "builtins.open",
         new_callable=__import__("unittest.mock", fromlist=["mock_open"]).mock_open,
@@ -546,10 +546,302 @@ class TestUploadAttachmentNormalisation:
         assert result["results"][0]["id"] == "att789"
 
 
+class TestGetContentProperty:
+    """Test get_content_property (v1 content properties)."""
+
+    @patch("requests.Session.get")
+    def test_returns_property_dict_when_found(self, mock_get, api):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "value": {"locked": True, "owner": "alice@host"},
+            "version": {"number": 3},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = api.get_content_property("page-1", "ccfm-lock")
+
+        assert result["value"]["locked"] is True
+        assert result["version"]["number"] == 3
+        mock_get.assert_called_once()
+        call_url = mock_get.call_args[0][0]
+        assert "/content/page-1/property/ccfm-lock" in call_url
+
+    @patch("requests.Session.get")
+    def test_returns_none_when_not_found(self, mock_get, api):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        result = api.get_content_property("page-1", "no-such-key")
+
+        assert result is None
+
+    @patch("requests.Session.get")
+    def test_raises_on_server_error(self, mock_get, api):
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
+        mock_get.return_value = mock_response
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            api.get_content_property("page-1", "key")
+
+
+class TestSetContentProperty:
+    """Test set_content_property (v1 content properties)."""
+
+    @patch("requests.Session.post")
+    def test_creates_property_when_no_version(self, mock_post, api):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        api.set_content_property("page-1", "ccfm-lock", {"locked": True})
+
+        mock_post.assert_called_once()
+        call_data = mock_post.call_args[1]["json"]
+        assert call_data["key"] == "ccfm-lock"
+        assert call_data["value"] == {"locked": True}
+        assert "version" not in call_data
+
+    @patch("requests.Session.put")
+    def test_updates_property_with_version(self, mock_put, api):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_put.return_value = mock_response
+
+        api.set_content_property("page-1", "ccfm-lock", {"locked": True}, version=5)
+
+        mock_put.assert_called_once()
+        call_data = mock_put.call_args[1]["json"]
+        assert call_data["version"]["number"] == 5
+        assert call_data["version"]["minorEdit"] is True
+
+    @patch("requests.Session.put")
+    def test_raises_on_conflict(self, mock_put, api):
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("409")
+        mock_put.return_value = mock_response
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            api.set_content_property("page-1", "key", {"x": 1}, version=2)
+
+
+class TestDeleteContentProperty:
+    """Test delete_content_property (v1 content properties)."""
+
+    @patch("requests.Session.delete")
+    def test_deletes_existing_property(self, mock_delete, api):
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status = Mock()
+        mock_delete.return_value = mock_response
+
+        api.delete_content_property("page-1", "ccfm-lock")
+
+        mock_delete.assert_called_once()
+        call_url = mock_delete.call_args[0][0]
+        assert "/content/page-1/property/ccfm-lock" in call_url
+
+    @patch("requests.Session.delete")
+    def test_no_op_when_not_found(self, mock_delete, api):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_delete.return_value = mock_response
+
+        api.delete_content_property("page-1", "missing-key")
+        # Should not raise
+
+    @patch("requests.Session.delete")
+    def test_raises_on_server_error(self, mock_delete, api):
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
+        mock_delete.return_value = mock_response
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            api.delete_content_property("page-1", "key")
+
+
+class TestDownloadAttachment:
+    """Test download_attachment (v1 attachment download)."""
+
+    @patch("requests.Session.get")
+    def test_downloads_attachment_content(self, mock_get, api):
+        list_response = Mock()
+        list_response.raise_for_status = Mock()
+        list_response.json.return_value = {
+            "results": [{"_links": {"download": "/download/attachments/123/state.json"}}]
+        }
+
+        download_response = Mock()
+        download_response.raise_for_status = Mock()
+        download_response.content = b'{"version":"1","pages":{}}'
+
+        mock_get.side_effect = [list_response, download_response]
+
+        result = api.download_attachment("page-1", "ccfm-state.json")
+
+        assert result == b'{"version":"1","pages":{}}'
+        assert mock_get.call_count == 2
+        # Second call should use the download link
+        download_url = mock_get.call_args_list[1][0][0]
+        assert "download/attachments/123/state.json" in download_url
+
+    @patch("requests.Session.get")
+    def test_returns_none_when_attachment_not_found(self, mock_get, api):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"results": []}
+        mock_get.return_value = mock_response
+
+        result = api.download_attachment("page-1", "missing.json")
+
+        assert result is None
+        mock_get.assert_called_once()
+
+
+class TestFindPageByLabel:
+    """Test find_page_by_label (v1 content search)."""
+
+    @patch("requests.Session.get")
+    def test_returns_page_id_when_found(self, mock_get, api):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [{"id": "mgmt-page-42", "title": "CCFM State Management"}]
+        }
+        mock_get.return_value = mock_response
+
+        result = api.find_page_by_label("DOCS", "ccfm-internal")
+
+        assert result == "mgmt-page-42"
+        call_params = mock_get.call_args[1]["params"]
+        assert call_params["spaceKey"] == "DOCS"
+        assert call_params["label"] == "ccfm-internal"
+
+    @patch("requests.Session.get")
+    def test_returns_none_when_no_results(self, mock_get, api):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"results": []}
+        mock_get.return_value = mock_response
+
+        result = api.find_page_by_label("DOCS", "ccfm-internal")
+
+        assert result is None
+
+
+class TestFindChildPageByTitle:
+    """Test find_child_page_by_title (v2 children API)."""
+
+    @patch("requests.Session.get")
+    def test_returns_page_id_when_child_found(self, mock_get, api):
+        """Returns page ID when a child with matching title exists."""
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {"id": "child-1", "title": "Other Page"},
+                {"id": "child-2", "title": "CCFM State Management"},
+            ],
+            "_links": {},
+        }
+        mock_get.return_value = mock_response
+
+        result = api.find_child_page_by_title("container-42", "CCFM State Management")
+
+        assert result == "child-2"
+        url = mock_get.call_args[0][0]
+        assert "container-42/children" in url
+
+    @patch("requests.Session.get")
+    def test_returns_none_when_no_matching_child(self, mock_get, api):
+        """Returns None when no child has the requested title."""
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [{"id": "child-1", "title": "Unrelated Page"}],
+            "_links": {},
+        }
+        mock_get.return_value = mock_response
+
+        result = api.find_child_page_by_title("container-42", "CCFM State Management")
+
+        assert result is None
+
+    @patch("requests.Session.get")
+    def test_returns_none_when_no_children(self, mock_get, api):
+        """Returns None when the parent has no children."""
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"results": [], "_links": {}}
+        mock_get.return_value = mock_response
+
+        result = api.find_child_page_by_title("container-42", "CCFM State Management")
+
+        assert result is None
+
+    @patch("requests.Session.get")
+    def test_paginates_until_match_found(self, mock_get, api):
+        """Follows the 'next' cursor link to find a child on the second page."""
+        first_response = Mock()
+        first_response.raise_for_status = Mock()
+        first_response.json.return_value = {
+            "results": [{"id": "child-1", "title": "Page A"}],
+            "_links": {"next": "/wiki/api/v2/pages/container-42/children?cursor=abc"},
+        }
+        second_response = Mock()
+        second_response.raise_for_status = Mock()
+        second_response.json.return_value = {
+            "results": [{"id": "child-2", "title": "CCFM State Management"}],
+            "_links": {},
+        }
+        mock_get.side_effect = [first_response, second_response]
+
+        result = api.find_child_page_by_title("container-42", "CCFM State Management")
+
+        assert result == "child-2"
+        assert mock_get.call_count == 2
+
+
+class TestUploadAttachmentNameParam:
+    """Test upload_attachment name parameter override."""
+
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
+    @patch("builtins.open", new_callable=mock_open, read_data=b"state data")
+    def test_name_overrides_filepath_name(self, mock_file, mock_post, mock_get, api):
+        """When name is provided, it's used instead of filepath.name."""
+        mock_get_response = Mock()
+        mock_get_response.status_code = 200
+        mock_get_response.json.return_value = {"results": []}
+        mock_get.return_value = mock_get_response
+
+        mock_post_response = Mock()
+        mock_post_response.status_code = 201
+        mock_post_response.json.return_value = {
+            "results": [{"id": "att-new", "title": "ccfm-state.json"}]
+        }
+        mock_post.return_value = mock_post_response
+
+        result = api.upload_attachment("page-1", Path("/tmp/abc123.tmp"), name="ccfm-state.json")
+
+        assert result is not None
+        # GET should query by the custom name
+        get_params = mock_get.call_args[1]["params"]
+        assert get_params["filename"] == "ccfm-state.json"
+        # POST file tuple should use custom name
+        post_files = mock_post.call_args[1]["files"]
+        assert post_files["file"][0] == "ccfm-state.json"
+
+
 class TestErrorHandling:
     """Test error handling across API methods."""
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_network_error(self, mock_get, api):
         """Test network error handling."""
         mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
@@ -557,7 +849,7 @@ class TestErrorHandling:
         with pytest.raises(requests.exceptions.ConnectionError):
             api.get_space_id("TEST")
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_authentication_error(self, mock_post, api):
         """Test authentication error."""
         mock_response = Mock()
@@ -569,7 +861,7 @@ class TestErrorHandling:
             body = {"version": 1, "type": "doc", "content": []}
             api.create_page("123", None, "Page", body)
 
-    @patch("ccfm_convert.deploy.api.requests.get")
+    @patch("requests.Session.get")
     def test_rate_limit_error(self, mock_get, api):
         """Test rate limit handling."""
         mock_response = Mock()
@@ -582,7 +874,7 @@ class TestErrorHandling:
         with pytest.raises(requests.exceptions.HTTPError):
             api.get_space_id("TEST")
 
-    @patch("ccfm_convert.deploy.api.requests.post")
+    @patch("requests.Session.post")
     def test_server_error(self, mock_post, api):
         """Test server error handling."""
         mock_response = Mock()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,121 @@
+"""Tests for state.backend module."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from ccfm_convert.state.backend import ConfluenceBackend, _empty_state
+
+
+class TestEmptyState:
+    def test_returns_version_and_empty_pages(self):
+        state = _empty_state()
+        assert state["version"] == "1"
+        assert state["pages"] == {}
+
+
+class TestConfluenceBackendLoad:
+    def test_load_returns_empty_state_when_no_attachment(self):
+        """Returns empty state when download_attachment returns None."""
+        api = Mock()
+        api.download_attachment.return_value = None
+        backend = ConfluenceBackend(api, "page-123")
+
+        result = backend.load()
+
+        assert result == _empty_state()
+        api.download_attachment.assert_called_once_with("page-123", "ccfm-state.json")
+
+    def test_load_parses_attachment_json(self):
+        """Parses valid JSON from attachment content."""
+        state_data = {
+            "version": "1",
+            "pages": {
+                "docs/guide.md": {
+                    "page_id": "42",
+                    "title": "Guide",
+                    "space_key": "DOCS",
+                    "space_id": "sid",
+                    "content_hash": "sha256:abc",
+                    "deployed_at": "2024-01-01T00:00:00+00:00",
+                }
+            },
+        }
+        api = Mock()
+        api.download_attachment.return_value = json.dumps(state_data).encode("utf-8")
+        backend = ConfluenceBackend(api, "page-123")
+
+        result = backend.load()
+
+        assert result["pages"]["docs/guide.md"]["page_id"] == "42"
+
+    def test_load_raises_on_invalid_schema_not_dict(self):
+        """Raises ValueError when attachment content is not a dict."""
+        api = Mock()
+        api.download_attachment.return_value = json.dumps(["not", "a", "dict"]).encode("utf-8")
+        backend = ConfluenceBackend(api, "page-123")
+
+        with pytest.raises(ValueError, match="unexpected schema"):
+            backend.load()
+
+    def test_load_raises_on_invalid_schema_no_pages(self):
+        """Raises ValueError when dict has no pages key."""
+        api = Mock()
+        api.download_attachment.return_value = json.dumps({"version": "1"}).encode("utf-8")
+        backend = ConfluenceBackend(api, "page-123")
+
+        with pytest.raises(ValueError, match="unexpected schema"):
+            backend.load()
+
+
+class TestConfluenceBackendSave:
+    def test_save_uploads_json_as_attachment(self, tmp_path):
+        """save() uploads state JSON to management page."""
+        api = Mock()
+        api.upload_attachment.return_value = {"results": [{"id": "att1"}]}
+        backend = ConfluenceBackend(api, "page-123")
+
+        state_data = {"version": "1", "pages": {"a.md": {"page_id": "1"}}}
+        backend.save(state_data)
+
+        api.upload_attachment.assert_called_once()
+        call_args = api.upload_attachment.call_args
+        assert call_args[1]["name"] == "ccfm-state.json"
+        # Verify the temp file was cleaned up
+        filepath = call_args[0][1]
+        assert not filepath.exists()
+
+    def test_save_cleans_up_temp_file_on_upload_failure(self):
+        """Temp file is deleted even if upload fails."""
+        api = Mock()
+        api.upload_attachment.side_effect = RuntimeError("Upload failed")
+        backend = ConfluenceBackend(api, "page-123")
+
+        with pytest.raises(RuntimeError, match="Upload failed"):
+            backend.save({"version": "1", "pages": {}})
+
+        # Temp file should still be cleaned up via finally block
+        api.upload_attachment.assert_called_once()
+
+    def test_save_writes_sorted_json(self):
+        """State data is written with sort_keys=True."""
+        api = Mock()
+        api.upload_attachment.return_value = {"results": [{"id": "att1"}]}
+        backend = ConfluenceBackend(api, "page-123")
+
+        state_data = {"version": "1", "pages": {"b.md": {"page_id": "2"}, "a.md": {"page_id": "1"}}}
+
+        # Capture the uploaded content by reading the temp file before it's deleted
+        uploaded_content = None
+
+        def capture_upload(page_id, filepath, name=None):
+            nonlocal uploaded_content
+            uploaded_content = filepath.read_bytes()
+            return {"results": [{"id": "att1"}]}
+
+        api.upload_attachment.side_effect = capture_upload
+        backend.save(state_data)
+
+        parsed = json.loads(uploaded_content.decode("utf-8"))
+        assert list(parsed["pages"].keys()) == sorted(parsed["pages"].keys())

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -102,16 +102,14 @@ class TestLoadConfig:
 
 class TestMergeConfigWithArgs:
     def test_config_fills_missing_cli_arg(self):
-        """Config value is applied when CLI arg is None (lines 94-99)."""
+        """Config value is applied when CLI arg is None."""
         config = {"domain": "from-config.atlassian.net"}
-        args = Namespace(
-            domain=None, email=None, token=None, space=None, docs_root=None, state=None
-        )
+        args = Namespace(domain=None, email=None, token=None, space=None, docs_root=None)
         merged = merge_config_with_args(config, args)
         assert merged.domain == "from-config.atlassian.net"
 
     def test_cli_arg_takes_precedence_over_config(self):
-        """Explicit CLI value is NOT overwritten by config (line 98 guard)."""
+        """Explicit CLI value is NOT overwritten by config."""
         config = {"domain": "from-config.atlassian.net"}
         args = Namespace(
             domain="cli.atlassian.net",
@@ -119,26 +117,21 @@ class TestMergeConfigWithArgs:
             token=None,
             space=None,
             docs_root=None,
-            state=None,
         )
         merged = merge_config_with_args(config, args)
         assert merged.domain == "cli.atlassian.net"
 
     def test_config_key_not_present_is_skipped(self):
-        """Missing config keys leave args unchanged (line 95-96)."""
+        """Missing config keys leave args unchanged."""
         config = {}
-        args = Namespace(
-            domain=None, email=None, token=None, space=None, docs_root=None, state=None
-        )
+        args = Namespace(domain=None, email=None, token=None, space=None, docs_root=None)
         merged = merge_config_with_args(config, args)
         assert merged.domain is None
 
     def test_docs_root_string_coerced_to_path(self):
-        """docs_root string from config is converted to Path (lines 102-103)."""
+        """docs_root string from config is converted to Path."""
         config = {"docs_root": "my/docs"}
-        args = Namespace(
-            domain=None, email=None, token=None, space=None, docs_root=None, state=None
-        )
+        args = Namespace(domain=None, email=None, token=None, space=None, docs_root=None)
         merged = merge_config_with_args(config, args)
         assert merged.docs_root == Path("my/docs")
         assert isinstance(merged.docs_root, Path)
@@ -152,28 +145,15 @@ class TestMergeConfigWithArgs:
             token=None,
             space=None,
             docs_root=Path("already/a/path"),
-            state=None,
         )
         merged = merge_config_with_args(config, args)
         assert merged.docs_root == Path("already/a/path")
 
-    def test_state_file_mapped_from_config_state_file_key(self):
-        """Config key 'state_file' maps to args.state (line 46: 'state_file': 'state')."""
-        config = {"state_file": ".my-state.json"}
-        args = Namespace(
-            domain=None, email=None, token=None, space=None, docs_root=None, state=None
-        )
-        merged = merge_config_with_args(config, args)
-        assert merged.state == ".my-state.json"
-
     def test_original_namespace_is_not_mutated(self):
         """merge_config_with_args returns a new Namespace, not mutating input."""
         config = {"domain": "new.atlassian.net"}
-        args = Namespace(
-            domain=None, email=None, token=None, space=None, docs_root=None, state=None
-        )
+        args = Namespace(domain=None, email=None, token=None, space=None, docs_root=None)
         merge_config_with_args(config, args)
-        # original should be unchanged
         assert args.domain is None
 
     def test_all_config_keys_are_applied(self):
@@ -185,7 +165,6 @@ class TestMergeConfigWithArgs:
             "space": "SP",
             "docs_root": "docs",
             "git_repo_url": "https://github.com/org/repo",
-            "state_file": ".state.json",
         }
         args = Namespace(
             domain=None,
@@ -194,7 +173,6 @@ class TestMergeConfigWithArgs:
             space=None,
             docs_root=None,
             git_repo_url=None,
-            state=None,
         )
         merged = merge_config_with_args(config, args)
         assert merged.domain == "d.atlassian.net"
@@ -203,4 +181,11 @@ class TestMergeConfigWithArgs:
         assert merged.space == "SP"
         assert merged.docs_root == Path("docs")
         assert merged.git_repo_url == "https://github.com/org/repo"
-        assert merged.state == ".state.json"
+
+    def test_state_file_key_is_ignored(self):
+        """state_file config key is no longer mapped (removed in remote state migration)."""
+        config = {"state_file": ".my-state.json"}
+        args = Namespace(domain=None, email=None, token=None, space=None, docs_root=None)
+        merged = merge_config_with_args(config, args)
+        # state_file should not be mapped to any arg
+        assert not hasattr(merged, "state") or merged.state is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,115 @@
+"""Tests for state.init module."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from ccfm_convert.state.init import (
+    CONTAINER_PAGE_TITLE,
+    MANAGEMENT_PAGE_LABEL,
+    MANAGEMENT_PAGE_TITLE,
+    init_remote_state,
+)
+
+
+@pytest.fixture
+def api():
+    api = Mock()
+    api.get_space_id.return_value = "space-123"
+    api.find_page_by_title.return_value = None
+    api.find_child_page_by_title.return_value = None
+    api.create_page.return_value = "new-page-id"
+    api.add_labels.return_value = None
+    return api
+
+
+class TestInitRemoteState:
+    def test_creates_container_and_management_page(self, api):
+        """Creates _ccfm container + CCFM State Management page when nothing exists."""
+        api.create_page.side_effect = ["container-id", "mgmt-id"]
+
+        result = init_remote_state(api, "DOCS", "space-123")
+
+        assert result == "mgmt-id"
+        assert api.create_page.call_count == 2
+
+        # First call creates container page
+        first_call = api.create_page.call_args_list[0]
+        assert first_call[0][0] == "space-123"  # space_id
+        assert first_call[0][1] is None  # parent_id (space root)
+        assert first_call[0][2] == CONTAINER_PAGE_TITLE
+
+        # Second call creates management page under container
+        second_call = api.create_page.call_args_list[1]
+        assert second_call[0][1] == "container-id"  # parent_id
+        assert second_call[0][2] == MANAGEMENT_PAGE_TITLE
+
+        # Label added to management page
+        api.add_labels.assert_called_once_with("mgmt-id", [MANAGEMENT_PAGE_LABEL])
+
+    def test_returns_existing_page_when_fully_initialized(self, api):
+        """Returns existing management page ID without creating anything when both pages exist."""
+        api.find_page_by_title.return_value = "existing-container-id"
+        api.find_child_page_by_title.return_value = "existing-mgmt-id"
+
+        result = init_remote_state(api, "DOCS", "space-123")
+
+        assert result == "existing-mgmt-id"
+        api.create_page.assert_not_called()
+        api.add_labels.assert_not_called()
+
+    def test_recreates_container_when_management_page_exists_but_container_missing(self, api):
+        """Recreates _ccfm container when it was deleted; management page becomes visible.
+
+        When the container was deleted but the management page survived (Confluence
+        cascade delete is not guaranteed), init must always recreate the container.
+        The management page won't be found via child-page lookup (it's orphaned),
+        so a fresh management page is created under the new container.
+        """
+        api.find_page_by_title.return_value = None  # container was deleted
+        api.find_child_page_by_title.return_value = None  # orphaned page not found as child
+        api.create_page.side_effect = ["new-container-id", "new-mgmt-id"]
+
+        result = init_remote_state(api, "DOCS", "space-123")
+
+        assert result == "new-mgmt-id"
+        # Both container and management page must be recreated
+        assert api.create_page.call_count == 2
+
+    def test_reuses_existing_container_page(self, api):
+        """If _ccfm container exists but management page doesn't, only creates management page."""
+        api.find_page_by_title.return_value = "existing-container-id"
+        api.find_child_page_by_title.return_value = None
+        api.create_page.return_value = "new-mgmt-id"
+
+        result = init_remote_state(api, "DOCS", "space-123")
+
+        assert result == "new-mgmt-id"
+        # Only one create_page call (management page, not container)
+        api.create_page.assert_called_once()
+        call_args = api.create_page.call_args
+        assert call_args[0][1] == "existing-container-id"  # parent is existing container
+        assert call_args[0][2] == MANAGEMENT_PAGE_TITLE
+
+    def test_find_child_page_by_title_called_with_correct_args(self, api):
+        """Passes container_id and MANAGEMENT_PAGE_TITLE to find_child_page_by_title."""
+        api.find_page_by_title.return_value = "existing-container-id"
+        api.find_child_page_by_title.return_value = "existing-mgmt-id"
+
+        init_remote_state(api, "MYSPACE", "space-456")
+
+        api.find_child_page_by_title.assert_called_once_with(
+            "existing-container-id", MANAGEMENT_PAGE_TITLE
+        )
+
+    def test_container_checked_before_management_page(self, api):
+        """Container existence is checked before management page lookup."""
+        api.find_page_by_title.return_value = "existing-container-id"
+        api.find_child_page_by_title.return_value = "existing-mgmt-id"
+
+        init_remote_state(api, "DOCS", "space-123")
+
+        # Verify call order: find_page_by_title (container) then find_child_page_by_title (mgmt)
+        title_idx = [c[0] for c in api.method_calls].index("find_page_by_title")
+        child_idx = [c[0] for c in api.method_calls].index("find_child_page_by_title")
+        assert title_idx < child_idx

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,231 @@
+"""Tests for state.lock module."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from ccfm_convert.state.lock import (
+    LOCK_PROPERTY_KEY,
+    LockError,
+    LockManager,
+    _default_owner,
+)
+
+
+@pytest.fixture
+def api():
+    return Mock()
+
+
+@pytest.fixture
+def lock_mgr(api):
+    return LockManager(api, "mgmt-page-123")
+
+
+class TestDefaultOwner:
+    @patch("ccfm_convert.state.lock.socket.gethostname", return_value="myhost")
+    @patch.dict("os.environ", {"USER": "alice"}, clear=False)
+    def test_returns_user_at_hostname(self, mock_hostname):
+        assert _default_owner() == "alice@myhost"
+
+    @patch("ccfm_convert.state.lock.socket.gethostname", return_value="myhost")
+    @patch.dict("os.environ", {"USER": "", "USERNAME": "bob"}, clear=False)
+    def test_falls_back_to_username_env(self, mock_hostname):
+        assert _default_owner() == "bob@myhost"
+
+    @patch("ccfm_convert.state.lock.socket.gethostname", return_value="myhost")
+    @patch.dict("os.environ", {"USER": "", "USERNAME": ""}, clear=False)
+    def test_falls_back_to_unknown(self, mock_hostname):
+        assert _default_owner() == "unknown@myhost"
+
+
+class TestLockStatus:
+    def test_status_returns_unlocked_when_no_property(self, lock_mgr, api):
+        """Returns unlocked LockInfo when property doesn't exist."""
+        api.get_content_property.return_value = None
+
+        info = lock_mgr.status()
+
+        assert info.locked is False
+        assert info.owner == ""
+        api.get_content_property.assert_called_once_with("mgmt-page-123", LOCK_PROPERTY_KEY)
+
+    def test_status_returns_lock_info_when_locked(self, lock_mgr, api):
+        """Returns full LockInfo when lock property exists."""
+        api.get_content_property.return_value = {
+            "value": {
+                "locked": True,
+                "owner": "alice@host",
+                "lock_id": "ci-123",
+                "locked_at": "2024-01-01T00:00:00+00:00",
+                "operation": "deploy",
+            },
+            "version": {"number": 3},
+        }
+
+        info = lock_mgr.status()
+
+        assert info.locked is True
+        assert info.owner == "alice@host"
+        assert info.lock_id == "ci-123"
+        assert info.locked_at == "2024-01-01T00:00:00+00:00"
+        assert info.operation == "deploy"
+        assert info.version == 3
+
+    def test_status_handles_missing_fields_gracefully(self, lock_mgr, api):
+        """Handles partial lock data without errors."""
+        api.get_content_property.return_value = {
+            "value": {"locked": True},
+            "version": {"number": 1},
+        }
+
+        info = lock_mgr.status()
+
+        assert info.locked is True
+        assert info.owner == ""
+        assert info.lock_id == ""
+
+
+class TestLockAcquire:
+    @patch("ccfm_convert.state.lock._default_owner", return_value="test@host")
+    def test_acquire_succeeds_when_unlocked_no_prior_version(self, mock_owner, lock_mgr, api):
+        """Acquire creates property when no prior lock exists."""
+        api.get_content_property.return_value = None
+
+        lock_mgr.acquire(operation="deploy", lock_id="ci-42")
+
+        api.set_content_property.assert_called_once()
+        call_args = api.set_content_property.call_args
+        assert call_args[0][0] == "mgmt-page-123"
+        assert call_args[0][1] == LOCK_PROPERTY_KEY
+        value = call_args[0][2]
+        assert value["locked"] is True
+        assert value["owner"] == "test@host"
+        assert value["lock_id"] == "ci-42"
+        assert value["operation"] == "deploy"
+        # No prior version → version=None
+        assert call_args[1]["version"] is None
+
+    @patch("ccfm_convert.state.lock._default_owner", return_value="test@host")
+    def test_acquire_succeeds_with_prior_unlocked_version(self, mock_owner, lock_mgr, api):
+        """Acquire uses version+1 when prior property exists but is unlocked."""
+        api.get_content_property.return_value = {
+            "value": {"locked": False},
+            "version": {"number": 5},
+        }
+
+        lock_mgr.acquire()
+
+        call_args = api.set_content_property.call_args
+        assert call_args[1]["version"] == 6
+
+    def test_acquire_raises_when_already_locked(self, lock_mgr, api):
+        """Raises LockError when lock is held by another process."""
+        api.get_content_property.return_value = {
+            "value": {
+                "locked": True,
+                "owner": "other@host",
+                "lock_id": "",
+                "locked_at": "2024-01-01T00:00:00+00:00",
+                "operation": "deploy",
+            },
+            "version": {"number": 2},
+        }
+
+        with pytest.raises(LockError, match="locked by other@host"):
+            lock_mgr.acquire()
+
+        api.set_content_property.assert_not_called()
+
+    def test_acquire_raises_when_locked_with_lock_id(self, lock_mgr, api):
+        """LockError message includes lock_id when present."""
+        api.get_content_property.return_value = {
+            "value": {
+                "locked": True,
+                "owner": "ci@runner",
+                "lock_id": "pipeline-99",
+                "locked_at": "2024-06-01T00:00:00+00:00",
+                "operation": "deploy",
+            },
+            "version": {"number": 1},
+        }
+
+        with pytest.raises(LockError, match="pipeline-99"):
+            lock_mgr.acquire()
+
+    @patch("ccfm_convert.state.lock._default_owner", return_value="test@host")
+    def test_acquire_raises_on_409_conflict(self, mock_owner, lock_mgr, api):
+        """409 Conflict from Confluence is converted to LockError."""
+        api.get_content_property.return_value = None
+
+        mock_response = Mock()
+        mock_response.status_code = 409
+        http_error = requests.HTTPError(response=mock_response)
+        api.set_content_property.side_effect = http_error
+
+        with pytest.raises(LockError, match="version conflict"):
+            lock_mgr.acquire()
+
+    @patch("ccfm_convert.state.lock._default_owner", return_value="test@host")
+    def test_acquire_propagates_non_409_http_errors(self, mock_owner, lock_mgr, api):
+        """Non-409 HTTP errors are re-raised as-is."""
+        api.get_content_property.return_value = None
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        http_error = requests.HTTPError(response=mock_response)
+        api.set_content_property.side_effect = http_error
+
+        with pytest.raises(requests.HTTPError):
+            lock_mgr.acquire()
+
+    @patch("ccfm_convert.state.lock._default_owner", return_value="test@host")
+    def test_acquire_defaults_lock_id_to_empty(self, mock_owner, lock_mgr, api):
+        """lock_id defaults to empty string when not provided."""
+        api.get_content_property.return_value = None
+
+        lock_mgr.acquire()
+
+        value = api.set_content_property.call_args[0][2]
+        assert value["lock_id"] == ""
+
+
+class TestLockRelease:
+    def test_release_deletes_lock_property_when_it_exists(self, lock_mgr, api):
+        """DELETE is called when the property exists."""
+        api.get_content_property.return_value = {
+            "value": {"locked": True, "owner": "x@h"},
+            "version": {"number": 1},
+        }
+
+        lock_mgr.release()
+
+        api.delete_content_property.assert_called_once_with("mgmt-page-123", LOCK_PROPERTY_KEY)
+
+    def test_release_is_noop_when_property_absent(self, lock_mgr, api):
+        """No DELETE when property has never been created (Confluence 403 guard)."""
+        api.get_content_property.return_value = None
+
+        lock_mgr.release()
+
+        api.delete_content_property.assert_not_called()
+
+    def test_force_release_deletes_when_property_exists(self, lock_mgr, api):
+        """force_release delegates to release, which DELETEs when property exists."""
+        api.get_content_property.return_value = {
+            "value": {"locked": True, "owner": "x@h"},
+            "version": {"number": 2},
+        }
+
+        lock_mgr.force_release()
+
+        api.delete_content_property.assert_called_once_with("mgmt-page-123", LOCK_PROPERTY_KEY)
+
+    def test_force_release_is_noop_when_property_absent(self, lock_mgr, api):
+        """force_release is a no-op when property doesn't exist."""
+        api.get_content_property.return_value = None
+
+        lock_mgr.force_release()
+
+        api.delete_content_property.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
-"""Tests for main.py CLI module."""
+"""Tests for main.py CLI module (subcommand-based CLI)."""
 
+import json
 import os
 from io import StringIO
 from pathlib import Path
@@ -10,114 +11,234 @@ import pytest
 import ccfm_convert.main as main
 from ccfm_convert.main import _derive_title, _rel_path
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_api():
-    """Create mock API."""
+    """Create mock API with common defaults."""
     api = Mock()
     api.get_space_id = Mock(return_value="space123")
+    api.find_page_by_title = Mock(return_value="container-id")
+    api.find_child_page_by_title = Mock(return_value="mgmt-page-id")
     api.create_page = Mock(return_value="page123")
     api.update_page = Mock()
     api.add_labels = Mock()
     return api
 
 
-class TestCLIArguments:
-    """Test CLI argument parsing."""
+def _base_deploy_argv(tmp_file_or_dir, *, is_dir=False, extra=None):
+    """Build a standard deploy sys.argv list."""
+    argv = [
+        "main.py",
+        "--domain",
+        "example.atlassian.net",
+        "--email",
+        "test@example.com",
+        "--token",
+        "token",
+        "--space",
+        "TEST",
+        "deploy",
+    ]
+    if is_dir:
+        argv += ["--directory", str(tmp_file_or_dir)]
+    else:
+        argv += ["--file", str(tmp_file_or_dir)]
+    if extra:
+        argv.extend(extra)
+    return argv
 
-    def test_required_arguments(self):
-        """Test that required arguments are enforced."""
-        with pytest.raises(SystemExit):
+
+def _base_init_argv():
+    """Build a standard init sys.argv list."""
+    return [
+        "main.py",
+        "--domain",
+        "example.atlassian.net",
+        "--email",
+        "test@example.com",
+        "--token",
+        "token",
+        "--space",
+        "TEST",
+        "init",
+    ]
+
+
+def _base_state_argv(subcommand, extra=None):
+    """Build a standard state sys.argv list."""
+    argv = [
+        "main.py",
+        "--domain",
+        "example.atlassian.net",
+        "--email",
+        "test@example.com",
+        "--token",
+        "token",
+        "--space",
+        "TEST",
+        "state",
+        subcommand,
+    ]
+    if extra:
+        argv.extend(extra)
+    return argv
+
+
+def _base_lock_argv(subcommand):
+    """Build a standard lock sys.argv list."""
+    return [
+        "main.py",
+        "--domain",
+        "example.atlassian.net",
+        "--email",
+        "test@example.com",
+        "--token",
+        "token",
+        "--space",
+        "TEST",
+        "lock",
+        subcommand,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _rel_path helper
+# ---------------------------------------------------------------------------
+
+
+class TestRelPath:
+    def test_rel_path_returns_relative_string_when_under_cwd(self, tmp_path):
+        """Returns relative path string when filepath is under cwd."""
+        original = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            f = tmp_path / "docs" / "page.md"
+            result = _rel_path(f)
+            assert result == "docs/page.md"
+        finally:
+            os.chdir(original)
+
+    def test_rel_path_returns_absolute_string_when_outside_cwd(self):
+        """Returns absolute path string when filepath is not under cwd."""
+        f = Path("/some/absolute/path/file.md")
+        result = _rel_path(f)
+        assert result == "/some/absolute/path/file.md"
+
+
+# ---------------------------------------------------------------------------
+# _derive_title helper
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveTitle:
+    def test_returns_frontmatter_title(self, tmp_path):
+        """Returns frontmatter title when page_meta.title is present."""
+        f = tmp_path / "my-page.md"
+        f.write_text("---\npage_meta:\n  title: Custom Title\n---\n# Content")
+        assert _derive_title(f) == "Custom Title"
+
+    def test_falls_back_to_stem_when_no_frontmatter(self, tmp_path):
+        """Returns stem-derived title when frontmatter has no title."""
+        f = tmp_path / "my-page.md"
+        f.write_text("# Content without frontmatter")
+        assert _derive_title(f) == "My Page"
+
+    def test_falls_back_to_stem_on_read_error(self, tmp_path):
+        """Returns stem-derived title when file cannot be read."""
+        f = tmp_path / "unreadable-doc.md"
+        # Don't create the file — read_text will raise OSError
+        assert _derive_title(f) == "Unreadable Doc"
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing and no-subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArguments:
+    """Test CLI argument parsing and routing."""
+
+    def test_no_subcommand_exits_with_error(self):
+        """No subcommand prints help and exits 1."""
+        with pytest.raises(SystemExit) as exc_info:
             with patch("sys.argv", ["main.py"]):
                 main.main()
+        assert exc_info.value.code == 1
 
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_single_file_deployment(self, mock_deploy, mock_api_class, tmp_path):
-        """Test deploying single file."""
-        # Create test file
+    def test_missing_credentials_exits_with_error(self, tmp_path):
+        """Missing required credentials cause SystemExit."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                ["main.py", "deploy", "--file", str(test_file)],
+            ):
+                main.main()
 
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.return_value = None
 
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--file",
-                str(test_file),
-            ],
-        ):
-            main.main()
+# ---------------------------------------------------------------------------
+# Init subcommand
+# ---------------------------------------------------------------------------
 
-        mock_deploy.assert_called_once()
 
+class TestInitSubcommand:
+    """Test the 'init' subcommand."""
+
+    @patch("ccfm_convert.main.init_remote_state")
     @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_directory_deployment(self, mock_deploy_tree, mock_api_class, tmp_path):
-        """Test deploying directory."""
-        # Create test directory
-        test_dir = tmp_path / "docs"
-        test_dir.mkdir()
-
+    def test_init_calls_init_remote_state(self, mock_api_class, mock_init, capsys):
+        """init subcommand creates API and calls init_remote_state."""
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
 
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--directory",
-                str(test_dir),
-            ],
-        ):
+        with patch("sys.argv", _base_init_argv()):
             main.main()
 
-        mock_deploy_tree.assert_called_once()
+        mock_init.assert_called_once_with(mock_api, "TEST", "space123")
+        captured = capsys.readouterr()
+        assert "Initialization complete" in captured.out
 
+    @patch("ccfm_convert.main.init_remote_state")
     @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_init_prints_space_lookup(self, mock_stdout, mock_api_class, mock_init):
+        """init prints the space lookup message."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        with patch("sys.argv", _base_init_argv()):
+            main.main()
+
+        output = mock_stdout.getvalue()
+        assert "Looking up space: TEST" in output
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — dump mode
+# ---------------------------------------------------------------------------
+
+
+class TestDeployDumpMode:
+    """Test deploy --dump (no API, no state, no lock)."""
+
     @patch("ccfm_convert.main.deploy_page")
-    def test_dump_mode(self, mock_deploy, mock_api_class, tmp_path):
-        """Test dump mode (no actual deployment)."""
+    def test_dump_file_calls_deploy_page_with_dump_true(self, mock_deploy, tmp_path):
+        """--dump with --file calls deploy_page(dump=True) without credentials."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
-        mock_api = Mock()
-        mock_api_class.return_value = mock_api
-
         with patch(
             "sys.argv",
             [
                 "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
+                "deploy",
                 "--file",
                 str(test_file),
                 "--dump",
@@ -125,341 +246,42 @@ class TestCLIArguments:
         ):
             main.main()
 
-        # Should not call get_space_id in dump mode
-        mock_api.get_space_id.assert_not_called()
-        # Should still call deploy_page with dump=True
         mock_deploy.assert_called_once()
         assert mock_deploy.call_args[1]["dump"] is True
 
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_no_file_or_directory(self, mock_api_class):
-        """Test error when neither file nor directory specified."""
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-
-        with pytest.raises(SystemExit):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "token",
-                    "--space",
-                    "TEST",
-                ],
-            ):
-                main.main()
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_custom_docs_root(self, mock_deploy, mock_api_class, tmp_path):
-        """Test custom docs root."""
-        custom_root = tmp_path / "custom_docs"
-        custom_root.mkdir()
-
-        test_file = custom_root / "test.md"
-        test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.return_value = None
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--docs-root",
-                str(custom_root),
-                "--file",
-                str(test_file),
-            ],
-        ):
-            main.main()
-
-        mock_deploy.assert_called_once()
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_with_git_repo_url(self, mock_deploy, mock_api_class, tmp_path):
-        """Test with git repo URL."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.return_value = None
-
-        git_url = "https://github.com/user/repo"
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--file",
-                str(test_file),
-                "--git-repo-url",
-                git_url,
-            ],
-        ):
-            main.main()
-
-        # Should pass git URL to deploy_page
-        call_args = mock_deploy.call_args[0]
-        assert call_args[4] == git_url
-
-
-class TestCLIIntegration:
-    """Test CLI integration scenarios."""
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.ensure_page_hierarchy")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_file_with_hierarchy(self, mock_deploy, mock_hierarchy, mock_api_class, tmp_path):
-        """Test file deployment with automatic hierarchy."""
-        docs_root = tmp_path / "docs"
-        subdir = docs_root / "Team"
-        subdir.mkdir(parents=True)
-
-        test_file = subdir / "page.md"
-        test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_hierarchy.return_value = "parent123"
-        mock_deploy.return_value = None
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--docs-root",
-                str(docs_root),
-                "--file",
-                str(test_file),
-            ],
-        ):
-            main.main()
-
-        # Should create hierarchy
-        mock_hierarchy.assert_called_once()
-        # Should pass parent_id to deploy_page
-        assert mock_deploy.call_args[0][2] == "parent123"
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
     @patch("ccfm_convert.main.deploy_tree")
-    def test_tree_deployment_with_git_url(self, mock_tree, mock_api_class, tmp_path):
-        """Test tree deployment with git URL."""
+    def test_dump_directory_calls_deploy_tree_with_dump_true(self, mock_deploy_tree, tmp_path):
+        """--dump with --directory calls deploy_tree(dump=True)."""
         test_dir = tmp_path / "docs"
         test_dir.mkdir()
 
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-
-        git_url = "https://github.com/user/repo"
-
         with patch(
             "sys.argv",
             [
                 "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
+                "deploy",
                 "--directory",
                 str(test_dir),
-                "--git-repo-url",
-                git_url,
+                "--dump",
             ],
         ):
             main.main()
 
-        # Should pass git URL to deploy_tree
-        call_args = mock_tree.call_args[0]
-        assert call_args[4] == git_url
+        mock_deploy_tree.assert_called_once()
+        assert mock_deploy_tree.call_args[1]["dump"] is True
 
-
-class TestErrorHandling:
-    """Test error handling in CLI."""
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_invalid_space(self, mock_api_class):
-        """Test handling of invalid space."""
-        mock_api = Mock()
-        mock_api.get_space_id.side_effect = ValueError("Space not found")
-        mock_api_class.return_value = mock_api
-
-        with pytest.raises(ValueError):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "token",
-                    "--space",
-                    "INVALID",
-                    "--file",
-                    "test.md",
-                ],
-            ):
-                main.main()
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_nonexistent_file(self, mock_deploy, mock_api_class):
-        """Test handling of non-existent file."""
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.side_effect = FileNotFoundError("File not found")
-
-        with pytest.raises(FileNotFoundError):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "token",
-                    "--space",
-                    "TEST",
-                    "--file",
-                    "nonexistent.md",
-                ],
-            ):
-                main.main()
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_api_error(self, mock_deploy, mock_api_class):
-        """Test handling of API errors."""
-        mock_api = Mock()
-        mock_api.get_space_id.side_effect = RuntimeError("API Error")
-        mock_api_class.return_value = mock_api
-
-        with pytest.raises(RuntimeError):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "token",
-                    "--space",
-                    "TEST",
-                    "--file",
-                    "test.md",
-                ],
-            ):
-                main.main()
-
-
-class TestOutput:
-    """Test CLI output."""
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
     @patch("ccfm_convert.main.deploy_page")
     @patch("sys.stdout", new_callable=StringIO)
-    def test_success_output(self, mock_stdout, mock_deploy, mock_api_class, tmp_path):
-        """Test success message output."""
+    def test_dump_mode_output(self, mock_stdout, mock_deploy, tmp_path):
+        """Dump mode prints 'Dump mode' and does NOT print 'Deployment complete'."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.return_value = None
 
         with patch(
             "sys.argv",
             [
                 "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--file",
-                str(test_file),
-            ],
-        ):
-            main.main()
-
-        output = mock_stdout.getvalue()
-        assert "Deployment complete" in output
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    @patch("sys.stdout", new_callable=StringIO)
-    def test_dump_mode_output(self, mock_stdout, mock_deploy, mock_api_class, tmp_path):
-        """Test dump mode output."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api_class.return_value = mock_api
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
+                "deploy",
                 "--file",
                 str(test_file),
                 "--dump",
@@ -471,29 +293,41 @@ class TestOutput:
         assert "Dump mode" in output
         assert "Deployment complete" not in output
 
-
-class TestPathHandling:
-    """Test path handling."""
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
     @patch("ccfm_convert.main.deploy_page")
-    def test_relative_path(self, mock_deploy, mock_api_class, tmp_path):
-        """Test with relative path."""
-        # Change to temp directory
-        import os
+    def test_dump_mode_with_git_repo_url(self, mock_deploy, tmp_path):
+        """--dump passes git_repo_url to deploy_page."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
 
-        original_cwd = os.getcwd()
-        os.chdir(tmp_path)
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "deploy",
+                "--file",
+                str(test_file),
+                "--dump",
+                "--git-repo-url",
+                "https://github.com/user/repo",
+            ],
+        ):
+            main.main()
 
-        try:
-            test_file = Path("test.md")
-            test_file.write_text("# Test")
+        call_args = mock_deploy.call_args[0]
+        assert call_args[4] == "https://github.com/user/repo"
 
-            mock_api = Mock()
-            mock_api.get_space_id.return_value = "space123"
-            mock_api_class.return_value = mock_api
-            mock_deploy.return_value = None
 
+# ---------------------------------------------------------------------------
+# Deploy subcommand — no file or directory
+# ---------------------------------------------------------------------------
+
+
+class TestDeployNoTarget:
+    """Test deploy without --file or --directory."""
+
+    def test_no_file_or_directory_exits_with_error(self):
+        """Deploy without --file or --directory exits 1."""
+        with pytest.raises(SystemExit):
             with patch(
                 "sys.argv",
                 [
@@ -506,55 +340,2334 @@ class TestPathHandling:
                     "token",
                     "--space",
                     "TEST",
-                    "--file",
-                    "test.md",
+                    "deploy",
                 ],
             ):
                 main.main()
 
-            mock_deploy.assert_called_once()
-        finally:
-            os.chdir(original_cwd)
 
+# ---------------------------------------------------------------------------
+# Deploy subcommand — plan mode
+# ---------------------------------------------------------------------------
+
+
+class TestDeployPlanMode:
+    """Test deploy --plan (needs credentials + mgmt page + state, no lock)."""
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_absolute_path(self, mock_deploy, mock_api_class, tmp_path):
-        """Test with absolute path."""
+    def test_plan_no_changes_exits_zero(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--plan exits 0 when there are no pending changes."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
+
+        mock_plan = Mock()
+        mock_plan.has_changes.return_value = False
+        mock_compute_plan.return_value = mock_plan
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_deploy_argv(test_file, extra=["--plan"])):
+                main.main()
+
+        assert exc_info.value.code == 0
+        mock_compute_plan.assert_called_once()
+        mock_plan.print_summary.assert_called_once()
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_has_changes_exits_zero_by_default(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--plan exits 0 even when there are pending changes (CI-friendly default)."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_plan = Mock()
+        mock_plan.has_changes.return_value = True
+        mock_compute_plan.return_value = mock_plan
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_deploy_argv(test_file, extra=["--plan"])):
+                main.main()
+
+        assert exc_info.value.code == 0
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_exit_code_has_changes_exits_two(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--plan --plan-exit-code exits 2 when there are pending changes."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_plan = Mock()
+        mock_plan.has_changes.return_value = True
+        mock_compute_plan.return_value = mock_plan
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch(
+                "sys.argv",
+                _base_deploy_argv(
+                    test_file,
+                    extra=["--plan", "--plan-exit-code"],
+                ),
+            ):
+                main.main()
+
+        assert exc_info.value.code == 2
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_exit_code_no_changes_exits_zero(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--plan --plan-exit-code exits 0 when there are no changes."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_plan = Mock()
+        mock_plan.has_changes.return_value = False
+        mock_compute_plan.return_value = mock_plan
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch(
+                "sys.argv",
+                _base_deploy_argv(
+                    test_file,
+                    extra=["--plan", "--plan-exit-code"],
+                ),
+            ):
+                main.main()
+
+        assert exc_info.value.code == 0
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_with_archive_orphans(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--plan --archive-orphans passes archive_orphans=True to compute_plan."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_compute_plan.return_value = Mock()
+
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                _base_deploy_argv(
+                    test_file,
+                    extra=["--plan", "--archive-orphans"],
+                ),
+            ):
+                main.main()
+
+        call_kwargs = mock_compute_plan.call_args[1]
+        assert call_kwargs["archive_orphans"] is True
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_with_directory_excludes_page_content_md(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--plan with --directory excludes .page_content.md files."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "a.md").write_text("# A")
+        (docs / ".page_content.md").write_text("# Container")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_compute_plan.return_value = Mock()
+
+        with pytest.raises(SystemExit):
+            with patch("sys.argv", _base_deploy_argv(docs, is_dir=True, extra=["--plan"])):
+                main.main()
+
+        call_kwargs = mock_compute_plan.call_args[1]
+        files = call_kwargs["files"]
+        assert all(f.name != ".page_content.md" for f in files)
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — live single-file deployment
+# ---------------------------------------------------------------------------
+
+
+class TestDeploySingleFile:
+    """Test single-file live deployment (with lock)."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_single_file_deployment(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Deploy a single file: acquires lock, deploys, saves state, releases lock."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = ("parent123", [])
+        mock_deploy.return_value = "deployed-page-id"
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(test_file)):
+            main.main()
+
+        mock_lock.acquire.assert_called_once()
+        mock_deploy.assert_called_once()
+        mock_state.set_page.assert_called_once()
+        mock_state.save.assert_called_once()
+        mock_lock.release.assert_called_once()
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_hierarchy_pages_tracked_in_state_for_single_file(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Hierarchy container pages returned by ensure_page_hierarchy are saved to state."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = ("parent123", [("docs/my-dir", "dir-pid", "My Dir")])
+        mock_deploy.return_value = "deployed-page-id"
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+
+        with patch("sys.argv", _base_deploy_argv(test_file)):
+            main.main()
+
+        # set_page called once for the hierarchy container + once for the page itself
+        assert mock_state.set_page.call_count == 2
+        hierarchy_call = mock_state.set_page.call_args_list[0]
+        assert hierarchy_call.kwargs["rel_path"] == "docs/my-dir"
+        assert hierarchy_call.kwargs["content_hash"] == ""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_not_saved_when_deploy_returns_none(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """state.set_page not called if deploy_page returns None; state.save always called."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None  # page skipped
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(test_file)):
+            main.main()
+
+        mock_state.set_page.assert_not_called()
+        mock_state.save.assert_called_once()
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_file_with_custom_docs_root(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """--docs-root is passed through to ensure_page_hierarchy."""
+        custom_root = tmp_path / "custom_docs"
+        custom_root.mkdir()
+        test_file = custom_root / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
 
         with patch(
             "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "token",
-                "--space",
-                "TEST",
-                "--file",
-                str(test_file.absolute()),
-            ],
+            _base_deploy_argv(
+                test_file,
+                extra=["--docs-root", str(custom_root)],
+            ),
         ):
             main.main()
 
         mock_deploy.assert_called_once()
 
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_file_with_git_repo_url(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """--git-repo-url is passed through to deploy_page."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        git_url = "https://github.com/user/repo"
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                test_file,
+                extra=["--git-repo-url", git_url],
+            ),
+        ):
+            main.main()
+
+        call_args = mock_deploy.call_args[0]
+        assert call_args[4] == git_url
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_file_with_hierarchy(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """ensure_page_hierarchy parent_id is passed to deploy_page."""
+        docs_root = tmp_path / "docs"
+        subdir = docs_root / "Team"
+        subdir.mkdir(parents=True)
+        test_file = subdir / "page.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = ("parent123", [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                test_file,
+                extra=["--docs-root", str(docs_root)],
+            ),
+        ):
+            main.main()
+
+        mock_hierarchy.assert_called_once()
+        assert mock_deploy.call_args[0][2] == "parent123"
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — live directory deployment
+# ---------------------------------------------------------------------------
+
+
+class TestDeployDirectory:
+    """Test directory live deployment (with lock)."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_directory_deployment(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Deploy a directory: calls deploy_tree."""
+        test_dir = tmp_path / "docs"
+        test_dir.mkdir()
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([], [])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(test_dir, is_dir=True)):
+            main.main()
+
+        mock_deploy_tree.assert_called_once()
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_saved_for_each_deployed_page_in_tree(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """state.set_page is called for each page_id returned from deploy_tree."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f1 = docs / "page1.md"
+        f2 = docs / "page2.md"
+        f1.write_text("# P1")
+        f2.write_text("# P2")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([(f1, "pid1"), (f2, "pid2")], [])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(docs, is_dir=True)):
+            main.main()
+
+        assert mock_state.set_page.call_count == 2
+        assert mock_state.save.call_count == 1
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_hierarchy_pages_tracked_in_state_for_tree(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Hierarchy container pages returned by deploy_tree are saved to state."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f1 = docs / "page.md"
+        f1.write_text("# P")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = (
+            [(f1, "pid1")],
+            [("docs/sub", "sub-pid", "Sub")],
+        )
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+
+        with patch("sys.argv", _base_deploy_argv(docs, is_dir=True)):
+            main.main()
+
+        # 1 hierarchy page + 1 content page
+        assert mock_state.set_page.call_count == 2
+        hierarchy_call = mock_state.set_page.call_args_list[0]
+        assert hierarchy_call.kwargs["rel_path"] == "docs/sub"
+        assert hierarchy_call.kwargs["content_hash"] == ""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_skips_none_page_ids_in_tree(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """page_id=None entries from deploy_tree are not written to state."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f1 = docs / "deployed.md"
+        f2 = docs / "skipped.md"
+        f1.write_text("# D")
+        f2.write_text("# S")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([(f1, "pid-ok"), (f2, None)], [])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(docs, is_dir=True)):
+            main.main()
+
+        assert mock_state.set_page.call_count == 1
+        assert mock_state.save.call_count == 1
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_tree_with_git_repo_url(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """--git-repo-url is passed through to deploy_tree."""
+        test_dir = tmp_path / "docs"
+        test_dir.mkdir()
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([], [])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        git_url = "https://github.com/user/repo"
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                test_dir,
+                is_dir=True,
+                extra=["--git-repo-url", git_url],
+            ),
+        ):
+            main.main()
+
+        call_args = mock_deploy_tree.call_args[0]
+        assert call_args[4] == git_url
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — --changed-only
+# ---------------------------------------------------------------------------
+
+
+class TestDeployChangedOnly:
+    """Test deploy --changed-only."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_changed_only_prints_count_message(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+        capsys,
+    ):
+        """--changed-only prints the count of changed files."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        changed = docs / "changed.md"
+        unchanged = docs / "unchanged.md"
+        changed.write_text("# New Content")
+        unchanged.write_text("# Old Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([], [])
+
+        # State mock: changed.md has_changed=True, unchanged.md has_changed=False
+        mock_state = Mock()
+        mock_state.has_changed.side_effect = lambda rel, f: f.name == "changed.md"
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--changed-only"],
+            ),
+        ):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "--changed-only: 1 file(s) with changes" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_zero_changes_does_not_call_deploy_tree(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+        capsys,
+    ):
+        """When --changed-only reports 0 changes, deploy_tree must not be called."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        unchanged = docs / "unchanged.md"
+        unchanged.write_text("# Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        # All files report as unchanged
+        mock_state = Mock()
+        mock_state.has_changed.return_value = False
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--changed-only"],
+            ),
+        ):
+            main.main()
+
+        mock_deploy_tree.assert_not_called()
+        mock_lock.acquire.assert_not_called()
+        captured = capsys.readouterr()
+        assert "No changes to deploy" in captured.out
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_zero_changes_does_not_archive_pages(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_archive,
+        tmp_path,
+    ):
+        """When --changed-only reports 0 changes, --archive-orphans must not run."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        unchanged = docs / "unchanged.md"
+        unchanged.write_text("# Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.has_changed.return_value = False
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--changed-only", "--archive-orphans"],
+            ),
+        ):
+            main.main()
+
+        mock_deploy_tree.assert_not_called()
+        mock_archive.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — --archive-orphans
+# ---------------------------------------------------------------------------
+
+
+class TestDeployArchiveOrphans:
+    """Test deploy --archive-orphans during live deployment."""
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_archive_orphans_calls_archive_and_removes_from_state(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_archive,
+        tmp_path,
+    ):
+        """Orphaned pages are archived and removed from state."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        active = docs / "active.md"
+        active.write_text("# Active")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([(active, "active-pid")], [])
+
+        mock_state = Mock()
+        mock_state.find_orphans.return_value = ["docs/deleted.md"]
+        mock_state.get_page.return_value = {"page_id": "orphan-pid", "title": "Deleted"}
+        mock_state_class.return_value = mock_state
+
+        mock_archive.return_value = True
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--archive-orphans"],
+            ),
+        ):
+            main.main()
+
+        mock_archive.assert_called_once_with(mock_api, "orphan-pid", "Deleted")
+        mock_state.remove_page.assert_called_once_with("docs/deleted.md")
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_archive_orphans_no_orphans_prints_message(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_archive,
+        tmp_path,
+        capsys,
+    ):
+        """When no orphans found, prints info message."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        active = docs / "active.md"
+        active.write_text("# Active")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([(active, "active-pid")], [])
+
+        mock_state = Mock()
+        mock_state.find_orphans.return_value = []
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--archive-orphans"],
+            ),
+        ):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "No orphaned pages found" in captured.out
+        mock_archive.assert_not_called()
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_archive_failure_does_not_remove_from_state(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_archive,
+        tmp_path,
+    ):
+        """If archive_page returns False, entry stays in state."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([], [])
+
+        mock_state = Mock()
+        mock_state.find_orphans.return_value = ["docs/orphan.md"]
+        mock_state.get_page.return_value = {"page_id": "orphan-id", "title": "Orphan"}
+        mock_state_class.return_value = mock_state
+
+        mock_archive.return_value = False  # simulate archive failure
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--archive-orphans"],
+            ),
+        ):
+            main.main()
+
+        mock_archive.assert_called_once()
+        mock_state.remove_page.assert_not_called()
+
+    @patch("ccfm_convert.main.archive_page")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_changed_only_with_archive_orphans_uses_all_files(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_archive,
+        tmp_path,
+    ):
+        """--changed-only + --archive-orphans: orphan detection uses all disk files."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        changed = docs / "changed.md"
+        unchanged = docs / "unchanged.md"
+        changed.write_text("# New Content")
+        unchanged.write_text("# Stable Content")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([(changed, "changed-pid")], [])
+
+        mock_state = Mock()
+        mock_state.has_changed.side_effect = lambda rel, f: "changed" in str(f)
+        mock_state.find_orphans.return_value = []
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                docs,
+                is_dir=True,
+                extra=["--changed-only", "--archive-orphans"],
+            ),
+        ):
+            main.main()
+
+        # find_orphans should receive all_files (both changed and unchanged)
+        call_args = mock_state.find_orphans.call_args[0]
+        all_files_passed = call_args[0]
+        filenames = {f.name for f in all_files_passed}
+        assert "changed.md" in filenames
+        assert "unchanged.md" in filenames
+        mock_archive.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — locking
+# ---------------------------------------------------------------------------
+
+
+class TestDeployLocking:
+    """Test deploy lock acquisition and release."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_error_exits_with_code_1(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """LockError during acquire exits with code 1."""
+        from ccfm_convert.state import LockError
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock.acquire.side_effect = LockError("State is locked")
+        mock_lock_class.return_value = mock_lock
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_deploy_argv(test_file)):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_released_even_on_deploy_error(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Lock is released in finally block even when deploy raises."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.side_effect = RuntimeError("deploy failed")
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with pytest.raises(RuntimeError):
+            with patch("sys.argv", _base_deploy_argv(test_file)):
+                main.main()
+
+        mock_lock.release.assert_called_once()
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_id_passed_to_acquire(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """--lock-id is forwarded to lock_mgr.acquire."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            _base_deploy_argv(
+                test_file,
+                extra=["--lock-id", "ci-run-42"],
+            ),
+        ):
+            main.main()
+
+        mock_lock.acquire.assert_called_once_with(operation="deploy", lock_id="ci-run-42")
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — management page not found
+# ---------------------------------------------------------------------------
+
+
+class TestManagementPageDiscovery:
+    """Test _find_management_page discovery."""
+
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_find_management_page_exits_when_container_missing(self, mock_api_class, tmp_path):
+        """_find_management_page exits 1 when _ccfm container page is not found."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api.find_page_by_title.return_value = None  # container not found
+        mock_api_class.return_value = mock_api
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_deploy_argv(test_file)):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_find_management_page_exits_when_child_missing(self, mock_api_class, tmp_path):
+        """_find_management_page exits 1 when container exists but management page child missing."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api.find_page_by_title.return_value = "container-id"
+        mock_api.find_child_page_by_title.return_value = None  # management page not found
+        mock_api_class.return_value = mock_api
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_deploy_argv(test_file)):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_find_management_page_returns_page_id(
+        self,
+        mock_api_class,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """_find_management_page returns page_id when container->child lookup succeeds."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api.find_page_by_title.return_value = "container-id"
+        mock_api.find_child_page_by_title.return_value = "found-mgmt-id"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(test_file)):
+            main.main()
+
+        # ConfluenceBackend should have been called with the found mgmt page id
+        mock_backend_class.assert_called_once_with(mock_api, "found-mgmt-id")
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — output
+# ---------------------------------------------------------------------------
+
+
+class TestDeployOutput:
+    """Test deploy CLI output messages."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_success_output(
+        self,
+        mock_stdout,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Success message output includes 'Deployment complete'."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(test_file)):
+            main.main()
+
+        output = mock_stdout.getvalue()
+        assert "Deployment complete" in output
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_space_id_printed(
+        self,
+        mock_stdout,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Space ID is printed during deployment."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_deploy_argv(test_file)):
+            main.main()
+
+        output = mock_stdout.getvalue()
+        assert "Space ID: space123" in output
+
+
+# ---------------------------------------------------------------------------
+# Deploy subcommand — error handling
+# ---------------------------------------------------------------------------
+
+
+class TestDeployErrorHandling:
+    """Test error handling during deployment."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_invalid_space(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """ValueError from get_space_id propagates."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.side_effect = ValueError("Space not found")
+        mock_api_class.return_value = mock_api
+
+        with pytest.raises(ValueError):
+            with patch("sys.argv", _base_deploy_argv(test_file)):
+                main.main()
+
+
+# ---------------------------------------------------------------------------
+# State subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestStateSubcommand:
+    """Test the 'state' subcommand."""
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_list_with_pages(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        capsys,
+    ):
+        """state list prints tracked pages."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.all_pages = {
+            "docs/page.md": {
+                "page_id": "pid1",
+                "title": "Page",
+                "deployed_at": "2026-01-01T00:00:00",
+            }
+        }
+        mock_state_class.return_value = mock_state
+
+        with patch("sys.argv", _base_state_argv("list")):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "Tracked pages (1)" in captured.out
+        assert "docs/page.md" in captured.out
+        assert "pid1" in captured.out
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_list_empty(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        capsys,
+    ):
+        """state list with no pages prints empty message."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.all_pages = {}
+        mock_state_class.return_value = mock_state
+
+        with patch("sys.argv", _base_state_argv("list")):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "No pages tracked in state" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_rm_removes_entry(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        capsys,
+    ):
+        """state rm removes the specified path from state with lock acquired."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.get_page.return_value = {"page_id": "pid1", "title": "Page"}
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_state_argv("rm", extra=["docs/page.md"])):
+            main.main()
+
+        mock_lock.acquire.assert_called_once_with(operation="state-rm")
+        mock_lock.release.assert_called_once()
+        mock_state.remove_page.assert_called_once_with("docs/page.md")
+        mock_state.save.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Removed 'docs/page.md' from state" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_rm_exits_when_locked(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+    ):
+        """state rm exits 1 if the space is already locked."""
+        from ccfm_convert.state.lock import LockError
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.get_page.return_value = {"page_id": "pid1", "title": "Page"}
+        mock_state_class.return_value = mock_state
+
+        mock_lock = Mock()
+        mock_lock.acquire.side_effect = LockError("locked by CI")
+        mock_lock_class.return_value = mock_lock
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("rm", extra=["docs/page.md"])):
+                main.main()
+
+        assert exc_info.value.code == 1
+        mock_lock.release.assert_not_called()
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_rm_unknown_path_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+    ):
+        """state rm with unknown path exits 1."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.get_page.return_value = None
+        mock_state_class.return_value = mock_state
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("rm", extra=["nonexistent.md"])):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_pull_prints_json(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        capsys,
+    ):
+        """state pull prints the raw state JSON to stdout."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.raw_state = {"version": "1", "pages": {"docs/a.md": {"page_id": "p1"}}}
+        mock_state_class.return_value = mock_state
+
+        with patch("sys.argv", _base_state_argv("pull")):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert '"version"' in captured.out
+        assert '"pages"' in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_overwrites_state(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        capsys,
+        tmp_path,
+    ):
+        """state push uploads the given JSON file as new remote state."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_backend = Mock()
+        mock_backend_class.return_value = mock_backend
+        mock_state_class.return_value = Mock(raw_state={})
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text('{"version": "1", "pages": {}}')
+
+        with patch("sys.argv", _base_state_argv("push", extra=[str(state_file)])):
+            main.main()
+
+        mock_backend.save.assert_called_once_with({"version": "1", "pages": {}})
+        mock_lock.acquire.assert_called_once()
+        mock_lock.release.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "updated" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_exits_when_locked(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """state push exits 1 if the space is already locked."""
+        from ccfm_convert.state.lock import LockError
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_state_class.return_value = Mock(raw_state={})
+
+        mock_lock = Mock()
+        mock_lock.acquire.side_effect = LockError("locked by CI")
+        mock_lock_class.return_value = mock_lock
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text('{"version": "1", "pages": {}}')
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("push", extra=[str(state_file)])):
+                main.main()
+
+        assert exc_info.value.code == 1
+        mock_lock.release.assert_not_called()
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_pages_not_dict_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """state push exits 1 when 'pages' key is not a dict."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_state_class.return_value = Mock()
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text('{"version": "1", "pages": []}')
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("push", extra=[str(bad_file)])):
+                main.main()
+
+        assert exc_info.value.code == 1
+        mock_lock.acquire.assert_not_called()
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_invalid_json_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """state push with malformed JSON exits 1."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_state_class.return_value = Mock()
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not-json")
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("push", extra=[str(bad_file)])):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_invalid_schema_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """state push with missing required keys exits 1."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_state_class.return_value = Mock()
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text('{"only_key": true}')
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("push", extra=[str(bad_file)])):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "../../admin",  # path traversal
+            "0",  # zero is not a valid Confluence page ID
+            "007",  # leading zeros rejected
+            "",  # empty string
+            12345,  # JSON integer (not a string) — exercises isinstance(pid, str) branch
+            None,  # JSON null — exercises isinstance(pid, str) branch
+        ],
+    )
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_invalid_page_id_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+        bad_id,
+    ):
+        """state push exits 1 when a page entry has an invalid page_id."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_state_class.return_value = Mock()
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text(
+            json.dumps({"version": "1", "pages": {"docs/a.md": {"page_id": bad_id}}})
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("push", extra=[str(bad_file)])):
+                main.main()
+
+        assert exc_info.value.code == 1
+        mock_lock.acquire.assert_not_called()
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_push_long_key_truncated_in_error(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+        capsys,
+    ):
+        """state push error message truncates oversized dict keys to 200 chars."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_state_class.return_value = Mock()
+        mock_lock_class.return_value = Mock()
+
+        long_key = "x" * 300
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text(
+            json.dumps({"version": "1", "pages": {long_key: {"page_id": "../../admin"}}})
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("push", extra=[str(bad_file)])):
+                main.main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "x" * 200 in captured.out
+        assert "x" * 201 not in captured.out
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_show_prints_entry(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+        capsys,
+    ):
+        """state show prints JSON for the requested path."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.get_page.return_value = {
+            "page_id": "pid1",
+            "title": "My Page",
+            "space_key": "TEST",
+            "space_id": "s1",
+            "content_hash": "sha256:abc",
+            "deployed_at": "2026-01-01T00:00:00",
+        }
+        mock_state_class.return_value = mock_state
+
+        with patch("sys.argv", _base_state_argv("show", extra=["docs/my-page.md"])):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "pid1" in captured.out
+        assert "My Page" in captured.out
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_state_show_unknown_path_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_backend_class,
+        mock_state_class,
+    ):
+        """state show with untracked path exits 1."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_state = Mock()
+        mock_state.get_page.return_value = None
+        mock_state_class.return_value = mock_state
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_state_argv("show", extra=["docs/ghost.md"])):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    def test_state_no_subcommand_exits(self):
+        """state without subcommand exits 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "token",
+                    "--space",
+                    "TEST",
+                    "state",
+                ],
+            ):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Lock subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestLockSubcommand:
+    """Test the 'lock' subcommand."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_status_not_locked(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_lock_class,
+        capsys,
+    ):
+        """lock status when unlocked prints 'State is not locked'."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_lock = Mock()
+        mock_info = Mock()
+        mock_info.locked = False
+        mock_lock.status.return_value = mock_info
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_lock_argv("status")):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "State is not locked" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_status_locked(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_lock_class,
+        capsys,
+    ):
+        """lock status when locked prints lock details."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_lock = Mock()
+        mock_info = Mock()
+        mock_info.locked = True
+        mock_info.owner = "user@host"
+        mock_info.lock_id = "ci-42"
+        mock_info.locked_at = "2026-01-01T00:00:00"
+        mock_info.operation = "deploy"
+        mock_lock.status.return_value = mock_info
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_lock_argv("status")):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "State is locked" in captured.out
+        assert "user@host" in captured.out
+        assert "ci-42" in captured.out
+        assert "deploy" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_status_locked_no_lock_id(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_lock_class,
+        capsys,
+    ):
+        """lock status when locked but no lock_id omits Lock ID line."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_lock = Mock()
+        mock_info = Mock()
+        mock_info.locked = True
+        mock_info.owner = "user@host"
+        mock_info.lock_id = ""
+        mock_info.locked_at = "2026-01-01T00:00:00"
+        mock_info.operation = "deploy"
+        mock_lock.status.return_value = mock_info
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_lock_argv("status")):
+            main.main()
+
+        captured = capsys.readouterr()
+        assert "Lock ID" not in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_release(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_lock_class,
+        capsys,
+    ):
+        """lock release calls force_release and prints confirmation."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_lock_argv("release")):
+            main.main()
+
+        mock_lock.force_release.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Lock released" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_acquire_success(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_lock_class,
+        capsys,
+    ):
+        """lock acquire prints confirmation when lock is acquired."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_lock = Mock()
+        mock_info = Mock()
+        mock_info.owner = "user@host"
+        mock_info.operation = "manual"
+        mock_lock.status.return_value = mock_info
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_lock_argv("acquire")):
+            main.main()
+
+        mock_lock.acquire.assert_called_once_with(operation="manual", lock_id=None)
+        captured = capsys.readouterr()
+        assert "user@host" in captured.out
+        assert "manual" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_lock_acquire_already_locked_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_lock_class,
+    ):
+        """lock acquire exits 1 when already locked."""
+        from ccfm_convert.state import LockError
+
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_lock = Mock()
+        mock_lock.acquire.side_effect = LockError("already locked by other@host")
+        mock_lock_class.return_value = mock_lock
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", _base_lock_argv("acquire")):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+    def test_lock_no_subcommand_exits(self):
+        """lock without subcommand exits 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "token",
+                    "--space",
+                    "TEST",
+                    "lock",
+                ],
+            ):
+                main.main()
+
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Config file loading
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFileLoading:
+    """Test ccfm.yaml config loading."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_config_file_loaded_when_ccfm_yaml_present(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """ccfm.yaml is auto-loaded if present."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        config_file = tmp_path / "ccfm.yaml"
+        config_file.write_text(
+            "version: 1\ndomain: config.atlassian.net\nemail: cfg@example.com\nspace: CFG\n"
+        )
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        original = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--token",
+                    "tok",
+                    "deploy",
+                    "--file",
+                    str(test_file),
+                ],
+            ):
+                main.main()
+        finally:
+            os.chdir(original)
+
+        mock_api_class.assert_called_once_with("config.atlassian.net", "cfg@example.com", "tok")
+
+    @patch("ccfm_convert.main.load_config")
+    def test_config_file_load_error_exits_with_code_1(self, mock_load_config, tmp_path):
+        """Bad config file causes sys.exit(1)."""
+        config_file = tmp_path / "ccfm.yaml"
+        config_file.write_text("bad: yaml: content")
+        mock_load_config.side_effect = Exception("parse error")
+
+        original = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                with patch(
+                    "sys.argv",
+                    [
+                        "main.py",
+                        "--token",
+                        "tok",
+                        "--config",
+                        str(config_file),
+                        "deploy",
+                        "--file",
+                        "test.md",
+                    ],
+                ):
+                    main.main()
+        finally:
+            os.chdir(original)
+
+        assert exc_info.value.code == 1
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_explicit_config_flag_loads_named_file(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """--config <path> loads the specified file."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        custom_config = tmp_path / "custom.yaml"
+        custom_config.write_text(
+            "version: 1\ndomain: custom.atlassian.net\nemail: custom@example.com\nspace: CUS\n"
+        )
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "--token",
+                "tok",
+                "--config",
+                str(custom_config),
+                "deploy",
+                "--file",
+                str(test_file),
+            ],
+        ):
+            main.main()
+
+        mock_api_class.assert_called_once_with("custom.atlassian.net", "custom@example.com", "tok")
+
+
+# ---------------------------------------------------------------------------
+# Token handling
+# ---------------------------------------------------------------------------
+
 
 class TestTokenHandling:
     """Test API token supplied via CLI arg or CONFLUENCE_TOKEN env var."""
 
-    @patch("ccfm_convert.main.ConfluenceAPI")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_page")
-    def test_token_from_env_var(self, mock_deploy, mock_api_class, tmp_path):
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_token_from_env_var(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
         """Token is read from CONFLUENCE_TOKEN env var when --token is not provided."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
@@ -562,7 +2675,13 @@ class TestTokenHandling:
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
 
         with patch.dict(os.environ, {"CONFLUENCE_TOKEN": "env-token-value"}):
             with patch(
@@ -575,6 +2694,7 @@ class TestTokenHandling:
                     "test@example.com",
                     "--space",
                     "TEST",
+                    "deploy",
                     "--file",
                     str(test_file),
                 ],
@@ -599,6 +2719,7 @@ class TestTokenHandling:
                         "test@example.com",
                         "--space",
                         "TEST",
+                        "deploy",
                         "--file",
                         "test.md",
                     ],
@@ -607,969 +2728,107 @@ class TestTokenHandling:
 
 
 # ---------------------------------------------------------------------------
-# _rel_path helper (lines 14-19)
+# Path handling
 # ---------------------------------------------------------------------------
 
 
-class TestRelPath:
-    def test_rel_path_returns_relative_string_when_under_cwd(self, tmp_path):
-        """Returns relative path string when filepath is under cwd (line 17)."""
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            f = tmp_path / "docs" / "page.md"
-            result = _rel_path(f)
-            assert result == "docs/page.md"
-        finally:
-            os.chdir(original)
-
-    def test_rel_path_returns_absolute_string_when_outside_cwd(self):
-        """Returns absolute path string when filepath is not under cwd (lines 18-19)."""
-        # Use an absolute path definitely not under cwd
-        f = Path("/some/absolute/path/file.md")
-        result = _rel_path(f)
-        assert result == "/some/absolute/path/file.md"
-
-
-# ---------------------------------------------------------------------------
-# _derive_title helper
-# ---------------------------------------------------------------------------
-
-
-class TestDeriveTitle:
-    def test_returns_frontmatter_title(self, tmp_path):
-        """Returns frontmatter title when page_meta.title is present (line 29)."""
-        f = tmp_path / "my-page.md"
-        f.write_text("---\npage_meta:\n  title: Custom Title\n---\n# Content")
-        assert _derive_title(f) == "Custom Title"
-
-    def test_falls_back_to_stem_when_no_frontmatter(self, tmp_path):
-        """Returns stem-derived title when frontmatter has no title."""
-        f = tmp_path / "my-page.md"
-        f.write_text("# Content without frontmatter")
-        assert _derive_title(f) == "My Page"
-
-    def test_falls_back_to_stem_on_read_error(self, tmp_path):
-        """Returns stem-derived title when file cannot be read (lines 30-31)."""
-        f = tmp_path / "unreadable-doc.md"
-        # Don't create the file — read_text will raise OSError
-        assert _derive_title(f) == "Unreadable Doc"
-
-
-# ---------------------------------------------------------------------------
-# Config file loading (lines 97-104)
-# ---------------------------------------------------------------------------
-
-
-class TestConfigFileLoading:
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_config_file_loaded_when_ccfm_yaml_present(self, mock_deploy, mock_api_class, tmp_path):
-        """ccfm.yaml is auto-loaded if present (lines 98-104)."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        config_file = tmp_path / "ccfm.yaml"
-        config_file.write_text(
-            "version: 1\ndomain: config.atlassian.net\nemail: cfg@example.com\nspace: CFG\n"
-        )
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.return_value = None
-
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            with patch(
-                "sys.argv",
-                ["main.py", "--token", "tok", "--file", str(test_file)],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        # domain was supplied by config file, not CLI
-        mock_api_class.assert_called_once_with("config.atlassian.net", "cfg@example.com", "tok")
-
-    @patch("ccfm_convert.main.load_config")
-    def test_config_file_load_error_exits_with_code_1(self, mock_load_config, tmp_path):
-        """Bad config file causes sys.exit(1) (lines 99-104)."""
-        config_file = tmp_path / "ccfm.yaml"
-        config_file.write_text("bad: yaml: content")
-        mock_load_config.side_effect = Exception("parse error")
-
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            with pytest.raises(SystemExit) as exc_info:
-                with patch(
-                    "sys.argv",
-                    [
-                        "main.py",
-                        "--token",
-                        "tok",
-                        "--file",
-                        "test.md",
-                        "--config",
-                        str(config_file),
-                    ],
-                ):
-                    main.main()
-        finally:
-            os.chdir(original)
-
-        assert exc_info.value.code == 1
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_page")
-    def test_explicit_config_flag_loads_named_file(self, mock_deploy, mock_api_class, tmp_path):
-        """--config <path> loads the specified file, not the default ccfm.yaml (lines 97-104)."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        custom_config = tmp_path / "custom.yaml"
-        custom_config.write_text(
-            "version: 1\ndomain: custom.atlassian.net\nemail: custom@example.com\nspace: CUS\n"
-        )
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy.return_value = None
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--token",
-                "tok",
-                "--config",
-                str(custom_config),
-                "--file",
-                str(test_file),
-            ],
-        ):
-            main.main()
-
-        mock_api_class.assert_called_once_with("custom.atlassian.net", "custom@example.com", "tok")
-
-
-# ---------------------------------------------------------------------------
-# --plan mode (lines 147-154)
-# ---------------------------------------------------------------------------
-
-
-class TestPlanMode:
-    @patch("ccfm_convert.main.compute_plan")
-    def test_plan_mode_no_changes_exits_zero(self, mock_compute_plan, tmp_path):
-        """--plan exits 0 when there are no pending changes."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = False
-        mock_compute_plan.return_value = mock_plan
-
-        with pytest.raises(SystemExit) as exc_info:
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--plan",
-                    "--file",
-                    str(test_file),
-                ],
-            ):
-                main.main()
-
-        assert exc_info.value.code == 0
-        mock_compute_plan.assert_called_once()
-        mock_plan.print_summary.assert_called_once()
-
-    @patch("ccfm_convert.main.compute_plan")
-    def test_plan_mode_has_changes_exits_zero_by_default(self, mock_compute_plan, tmp_path):
-        """--plan exits 0 even when there are pending changes (CI-friendly)."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = True
-        mock_compute_plan.return_value = mock_plan
-
-        with pytest.raises(SystemExit) as exc_info:
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--plan",
-                    "--file",
-                    str(test_file),
-                ],
-            ):
-                main.main()
-
-        assert exc_info.value.code == 0
-
-    @patch("ccfm_convert.main.compute_plan")
-    def test_plan_exit_code_has_changes_exits_two(self, mock_compute_plan, tmp_path):
-        """--plan --plan-exit-code exits 2 when there are pending changes."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = True
-        mock_compute_plan.return_value = mock_plan
-
-        with pytest.raises(SystemExit) as exc_info:
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--plan",
-                    "--plan-exit-code",
-                    "--file",
-                    str(test_file),
-                ],
-            ):
-                main.main()
-
-        assert exc_info.value.code == 2
-
-    @patch("ccfm_convert.main.compute_plan")
-    def test_plan_exit_code_no_changes_exits_zero(self, mock_compute_plan, tmp_path):
-        """--plan --plan-exit-code exits 0 when there are no changes."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = False
-        mock_compute_plan.return_value = mock_plan
-
-        with pytest.raises(SystemExit) as exc_info:
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--plan",
-                    "--plan-exit-code",
-                    "--file",
-                    str(test_file),
-                ],
-            ):
-                main.main()
-
-        assert exc_info.value.code == 0
-
-    @patch("ccfm_convert.main.compute_plan")
-    def test_plan_mode_with_archive_orphans(self, mock_compute_plan, tmp_path):
-        """--plan --archive-orphans passes archive_orphans=True to compute_plan."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_compute_plan.return_value = Mock()
-
-        with pytest.raises(SystemExit):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--plan",
-                    "--archive-orphans",
-                    "--file",
-                    str(test_file),
-                ],
-            ):
-                main.main()
-
-        call_kwargs = mock_compute_plan.call_args[1]
-        assert call_kwargs["archive_orphans"] is True
-
-    @patch("ccfm_convert.main.compute_plan")
-    def test_plan_mode_with_directory(self, mock_compute_plan, tmp_path):
-        """--plan with --directory collects md files for the plan."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        (docs / "a.md").write_text("# A")
-        (docs / ".page_content.md").write_text("# Container")
-
-        mock_compute_plan.return_value = Mock()
-
-        with pytest.raises(SystemExit):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--plan",
-                    "--directory",
-                    str(docs),
-                ],
-            ):
-                main.main()
-
-        # .page_content.md excluded; only a.md in target_files
-        call_kwargs = mock_compute_plan.call_args[1]
-        files = call_kwargs["files"]
-        assert all(f.name != ".page_content.md" for f in files)
-
-
-# ---------------------------------------------------------------------------
-# --changed-only (lines 160-165)
-# ---------------------------------------------------------------------------
-
-
-class TestChangedOnlyMode:
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_changed_only_prints_count_message(
-        self, mock_deploy_tree, mock_api_class, tmp_path, capsys
-    ):
-        """--changed-only prints the count of changed files (lines 160-165)."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        changed = docs / "changed.md"
-        unchanged = docs / "unchanged.md"
-        changed.write_text("# New Content")
-        unchanged.write_text("# Old Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = []
-
-        # Pre-populate state so 'unchanged.md' already matches its hash
-        from ccfm_convert.state.manager import StateManager
-
-        state_file = tmp_path / ".ccfm-state.json"
-        sm = StateManager(state_file)
-
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            unchanged_rel = str(unchanged.relative_to(tmp_path))
-            sm.set_page(unchanged_rel, "p1", "Unchanged", "TEST", "s1", sm.compute_hash(unchanged))
-            sm.save()
-
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--changed-only",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        captured = capsys.readouterr()
-        # 'changed.md' has no state entry → has_changed=True; 'unchanged.md' matches → filtered out
-        assert "--changed-only: 1 file(s) with changes" in captured.out
-
-
-# ---------------------------------------------------------------------------
-# --dump with directory (lines 174-175)
-# ---------------------------------------------------------------------------
-
-
-class TestDumpModeDirectory:
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_dump_mode_directory_calls_deploy_tree_with_dump_true(self, mock_deploy_tree, tmp_path):
-        """dump mode with --directory calls deploy_tree(dump=True) (lines 174-175)."""
-        test_dir = tmp_path / "docs"
-        test_dir.mkdir()
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "tok",
-                "--space",
-                "TEST",
-                "--directory",
-                str(test_dir),
-                "--dump",
-            ],
-        ):
-            main.main()
-
-        mock_deploy_tree.assert_called_once()
-        call_kwargs = mock_deploy_tree.call_args[1]
-        assert call_kwargs.get("dump") is True
-
-
-# ---------------------------------------------------------------------------
-# State save after file deploy (lines 192-200)
-# ---------------------------------------------------------------------------
-
-
-class TestStateSaveAfterFileDeploy:
-    @patch("ccfm_convert.main.ConfluenceAPI")
+class TestPathHandling:
+    """Test path handling for file arguments."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
-    def test_state_saved_after_successful_file_deploy(
-        self, mock_hierarchy, mock_deploy, mock_api_class, tmp_path
-    ):
-        """state.set_page and state.save are called when deploy_page returns a page_id (lines 192-200)."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_hierarchy.return_value = None
-        mock_deploy.return_value = "deployed-page-id"
-
-        state_file = tmp_path / ".ccfm-state.json"
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "tok",
-                "--space",
-                "TEST",
-                "--file",
-                str(test_file),
-                "--state",
-                str(state_file),
-            ],
-        ):
-            main.main()
-
-        import json
-
-        assert state_file.exists()
-        data = json.loads(state_file.read_text())
-        assert any(v["page_id"] == "deployed-page-id" for v in data["pages"].values())
-
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_relative_path(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Relative path is accepted for --file."""
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            test_file = Path("test.md")
+            test_file.write_text("# Test")
+
+            mock_api = Mock()
+            mock_api.get_space_id.return_value = "space123"
+            mock_api_class.return_value = mock_api
+            mock_hierarchy.return_value = (None, [])
+            mock_deploy.return_value = None
+
+            mock_state = Mock()
+            mock_state_class.return_value = mock_state
+            mock_lock = Mock()
+            mock_lock_class.return_value = mock_lock
+
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "token",
+                    "--space",
+                    "TEST",
+                    "deploy",
+                    "--file",
+                    "test.md",
+                ],
+            ):
+                main.main()
+
+            mock_deploy.assert_called_once()
+        finally:
+            os.chdir(original_cwd)
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
-    def test_state_not_saved_when_deploy_returns_none(
-        self, mock_hierarchy, mock_deploy, mock_api_class, tmp_path
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_absolute_path(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_hierarchy,
+        mock_deploy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
     ):
-        """state.save not called if deploy_page returns None (lines 191 condition)."""
+        """Absolute path is accepted for --file."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
-        mock_hierarchy.return_value = None
-        mock_deploy.return_value = None  # skipped page
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
 
-        state_file = tmp_path / ".ccfm-state.json"
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
 
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "tok",
-                "--space",
-                "TEST",
-                "--file",
-                str(test_file),
-                "--state",
-                str(state_file),
-            ],
-        ):
+        with patch("sys.argv", _base_deploy_argv(test_file.absolute())):
             main.main()
 
-        assert not state_file.exists()
-
-
-# ---------------------------------------------------------------------------
-# State save after tree deploy (lines 207-216)
-# ---------------------------------------------------------------------------
-
-
-class TestStateSaveAfterTreeDeploy:
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_state_saved_for_each_deployed_page_in_tree(
-        self, mock_deploy_tree, mock_api_class, tmp_path
-    ):
-        """state.set_page is called per page_id returned from deploy_tree (lines 207-216)."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        f1 = docs / "page1.md"
-        f2 = docs / "page2.md"
-        f1.write_text("# P1")
-        f2.write_text("# P2")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        # deploy_tree returns (filepath, page_id) tuples
-        mock_deploy_tree.return_value = [(f1, "pid1"), (f2, "pid2")]
-
-        state_file = tmp_path / ".ccfm-state.json"
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "tok",
-                "--space",
-                "TEST",
-                "--directory",
-                str(docs),
-                "--state",
-                str(state_file),
-            ],
-        ):
-            main.main()
-
-        import json
-
-        data = json.loads(state_file.read_text())
-        page_ids = {v["page_id"] for v in data["pages"].values()}
-        assert "pid1" in page_ids
-        assert "pid2" in page_ids
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_state_skips_none_page_ids_in_tree(self, mock_deploy_tree, mock_api_class, tmp_path):
-        """page_id=None entries from deploy_tree are not written to state (line 207 condition)."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        f1 = docs / "deployed.md"
-        f2 = docs / "skipped.md"
-        f1.write_text("# D")
-        f2.write_text("# S")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = [(f1, "pid-ok"), (f2, None)]
-
-        state_file = tmp_path / ".ccfm-state.json"
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "--domain",
-                "example.atlassian.net",
-                "--email",
-                "test@example.com",
-                "--token",
-                "tok",
-                "--space",
-                "TEST",
-                "--directory",
-                str(docs),
-                "--state",
-                str(state_file),
-            ],
-        ):
-            main.main()
-
-        import json
-
-        data = json.loads(state_file.read_text())
-        page_ids = {v["page_id"] for v in data["pages"].values()}
-        assert "pid-ok" in page_ids
-        assert len(page_ids) == 1
-
-
-# ---------------------------------------------------------------------------
-# --archive-orphans live deploy (lines 222-233)
-# ---------------------------------------------------------------------------
-
-
-class TestChangedOnlyEarlyExit:
-    """--changed-only with 0 changes must exit before any deploy or archive."""
-
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_zero_changes_does_not_call_deploy_tree(
-        self, mock_deploy_tree, mock_api_class, tmp_path, capsys
-    ):
-        """When --changed-only reports 0 changes, deploy_tree must not be called."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        unchanged = docs / "unchanged.md"
-        unchanged.write_text("# Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = []
-
-        from ccfm_convert.state.manager import StateManager
-
-        state_file = tmp_path / ".ccfm-state.json"
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            sm = StateManager(state_file)
-            unchanged_rel = str(unchanged.relative_to(tmp_path))
-            sm.set_page(unchanged_rel, "p1", "Unchanged", "TEST", "s1", sm.compute_hash(unchanged))
-            sm.save()
-
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--changed-only",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        mock_deploy_tree.assert_not_called()
-        captured = capsys.readouterr()
-        assert "No changes to deploy" in captured.out
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_zero_changes_does_not_archive_pages(
-        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path
-    ):
-        """When --changed-only reports 0 changes, --archive-orphans must not run."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        unchanged = docs / "unchanged.md"
-        unchanged.write_text("# Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = []
-
-        from ccfm_convert.state.manager import StateManager
-
-        state_file = tmp_path / ".ccfm-state.json"
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            sm = StateManager(state_file)
-            unchanged_rel = str(unchanged.relative_to(tmp_path))
-            sm.set_page(unchanged_rel, "p1", "Unchanged", "TEST", "s1", sm.compute_hash(unchanged))
-            sm.save()
-
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--changed-only",
-                    "--archive-orphans",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        mock_deploy_tree.assert_not_called()
-        mock_archive.assert_not_called()
-
-
-class TestChangedOnlyWithArchiveOrphans:
-    """--changed-only + --archive-orphans: orphan detection uses all disk files, not just changed ones."""
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_unchanged_files_on_disk_are_not_treated_as_orphans(
-        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path
-    ):
-        """Unchanged files still present on disk must not be archived even if
-        --changed-only excludes them from the deploy set.
-
-        Regression test for issue #3 (Bug 2): find_orphans must receive all current
-        disk files, not the --changed-only-filtered subset.
-        """
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        changed = docs / "changed.md"
-        unchanged = docs / "unchanged.md"
-        changed.write_text("# New Content")
-        unchanged.write_text("# Stable Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = [(changed, "changed-pid")]
-        mock_archive.return_value = True
-
-        from ccfm_convert.state.manager import StateManager
-
-        state_file = tmp_path / ".ccfm-state.json"
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            sm = StateManager(state_file)
-            unchanged_rel = str(unchanged.relative_to(tmp_path))
-            # 'unchanged' is already in state with a matching hash → has_changed=False
-            sm.set_page(
-                unchanged_rel,
-                "unchanged-pid",
-                "Unchanged",
-                "TEST",
-                "s1",
-                sm.compute_hash(unchanged),
-            )
-            sm.save()
-
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--changed-only",
-                    "--archive-orphans",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        # 'unchanged.md' is on disk — must not be archived even though it was
-        # excluded from target_files by --changed-only
-        mock_archive.assert_not_called()
-
-
-class TestArchiveOrphansLiveDeploy:
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_archive_orphans_calls_archive_and_removes_from_state(
-        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path
-    ):
-        """Orphaned pages are archived and removed from state (lines 222-231)."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        active = docs / "active.md"
-        active.write_text("# Active")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = [(active, "active-pid")]
-        mock_archive.return_value = True
-
-        state_file = tmp_path / ".ccfm-state.json"
-
-        # Pre-populate state with a now-deleted page
-        from ccfm_convert.state.manager import StateManager
-
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            sm = StateManager(state_file)
-            sm.set_page("docs/deleted.md", "orphan-pid", "Deleted", "TEST", "s1", "sha256:x")
-            sm.save()
-
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--archive-orphans",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        mock_archive.assert_called_once_with(mock_api, "orphan-pid", "Deleted")
-
-        import json
-
-        data = json.loads(state_file.read_text())
-        assert "docs/deleted.md" not in data["pages"]
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_archive_orphans_no_orphans_prints_message(
-        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path, capsys
-    ):
-        """When no orphans found, prints info message (lines 232-233)."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        active = docs / "active.md"
-        active.write_text("# Active")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = [(active, "active-pid")]
-
-        state_file = tmp_path / ".ccfm-state.json"
-
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--archive-orphans",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        captured = capsys.readouterr()
-        assert "No orphaned pages found" in captured.out
-        mock_archive.assert_not_called()
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_archive_failure_does_not_remove_from_state(
-        self, mock_deploy_tree, mock_api_class, mock_archive, tmp_path
-    ):
-        """If archive_page returns False, entry stays in state (line 229 condition)."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = []
-        mock_archive.return_value = False  # simulate archive failure
-
-        state_file = tmp_path / ".ccfm-state.json"
-
-        from ccfm_convert.state.manager import StateManager
-
-        original = os.getcwd()
-        os.chdir(tmp_path)
-        try:
-            sm = StateManager(state_file)
-            sm.set_page("docs/orphan.md", "orphan-id", "Orphan", "TEST", "s1", "sha256:x")
-            sm.save()
-
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "tok",
-                    "--space",
-                    "TEST",
-                    "--directory",
-                    str(docs),
-                    "--archive-orphans",
-                    "--state",
-                    str(state_file),
-                ],
-            ):
-                main.main()
-        finally:
-            os.chdir(original)
-
-        import json
-
-        data = json.loads(state_file.read_text())
-        # Entry should still be present since archive failed
-        assert "docs/orphan.md" in data["pages"]
+        mock_deploy.assert_called_once()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -36,7 +36,7 @@ class TestEnsurePageHierarchy:
 
         filepath = docs_root / "page.md"
 
-        parent_id = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
+        parent_id, _ = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
 
         # Should return None (no parent needed)
         assert parent_id is None
@@ -52,7 +52,7 @@ class TestEnsurePageHierarchy:
         mock_api.find_page_by_title.return_value = None
         mock_api.create_page.return_value = "parent-123"
 
-        parent_id = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
+        parent_id, _ = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
 
         # Should create parent page and return its ID
         assert parent_id == "parent-123"
@@ -91,7 +91,7 @@ class TestEnsurePageHierarchy:
         # Parent already exists
         mock_api.find_page_by_title.return_value = "existing-123"
 
-        parent_id = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
+        parent_id, _ = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
 
         # Should return existing page ID
         assert parent_id == "existing-123"
@@ -377,7 +377,7 @@ class TestEnsurePageHierarchyCoverage:
         # Simulate page already exists
         mock_api.find_page_by_title.return_value = "existing-team-page"
 
-        parent_id = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
+        parent_id, _ = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
 
         # Should update the existing page
         mock_api.update_page.assert_called_once()
@@ -431,6 +431,21 @@ class TestEnsurePageHierarchyCoverage:
 class TestEnsurePageHierarchyEdgeCases:
     """Tests targeting remaining edge cases in ensure_page_hierarchy."""
 
+    def test_symlink_escaping_docs_root_raises(self, mock_api, tmp_path):
+        """Symlink inside docs_root that resolves outside it raises ValueError."""
+        docs_root = tmp_path / "docs"
+        docs_root.mkdir()
+
+        # Create a symlink inside docs_root pointing to parent (outside docs_root)
+        evil_link = docs_root / "escape"
+        evil_link.symlink_to(tmp_path)
+
+        # filepath appears to be inside docs/escape/
+        filepath = evil_link / "page.md"
+
+        with pytest.raises(ValueError, match="resolves outside docs_root"):
+            ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
+
     def test_filepath_not_under_docs_root_returns_none(self, mock_api, tmp_path):
         """Lines 33-35: when filepath is not relative to docs_root, returns None."""
         docs_root = tmp_path / "docs"
@@ -441,7 +456,7 @@ class TestEnsurePageHierarchyEdgeCases:
         other_dir.mkdir()
         filepath = other_dir / "page.md"
 
-        result = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
+        result, _ = ensure_page_hierarchy(mock_api, "space123", filepath, docs_root)
 
         assert result is None
         mock_api.create_page.assert_not_called()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from unittest.mock import Mock
 
 from ccfm_convert.plan.planner import DeployPlan, OrphanAction, PageAction, compute_plan
 from ccfm_convert.state.manager import StateManager
@@ -12,7 +13,9 @@ from ccfm_convert.state.manager import StateManager
 
 
 def _make_state(tmp_path) -> StateManager:
-    return StateManager(tmp_path / ".ccfm-state.json")
+    backend = Mock()
+    backend.load.return_value = {"version": "1", "pages": {}}
+    return StateManager(backend)
 
 
 def _write_md(directory: Path, name: str, content: str = "# Hello") -> Path:

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,8 +1,9 @@
 """Tests for state.manager.StateManager."""
 
 import hashlib
-import json
+import os
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -10,15 +11,17 @@ from ccfm_convert.state.manager import StateManager
 
 
 @pytest.fixture
-def state_path(tmp_path):
-    """Return a path for a state file inside tmp_path."""
-    return tmp_path / ".ccfm-state.json"
+def mock_backend():
+    """Return a mock StateBackend."""
+    backend = Mock()
+    backend.load.return_value = {"version": "1", "pages": {}}
+    return backend
 
 
 @pytest.fixture
-def manager(state_path):
-    """Return a fresh StateManager with no prior state."""
-    return StateManager(state_path)
+def manager(mock_backend):
+    """Return a fresh StateManager with a mock backend."""
+    return StateManager(mock_backend)
 
 
 class TestInit:
@@ -26,18 +29,10 @@ class TestInit:
         assert manager._state["version"] == StateManager.STATE_VERSION
         assert manager._state["pages"] == {}
 
-    def test_path_is_stored(self, state_path, manager):
-        assert manager.path == state_path
-
 
 class TestLoad:
-    def test_load_no_op_when_file_absent(self, manager):
-        """load() is silent when the state file does not exist (line 32-33)."""
-        manager.load()
-        assert manager._state["pages"] == {}
-
-    def test_load_reads_existing_file(self, state_path, manager):
-        """load() deserialises JSON from disk (lines 34-36)."""
+    def test_load_delegates_to_backend(self, manager, mock_backend):
+        """load() calls backend.load() and stores the result."""
         existing = {
             "version": "1",
             "pages": {
@@ -51,59 +46,26 @@ class TestLoad:
                 }
             },
         }
-        state_path.write_text(json.dumps(existing), encoding="utf-8")
+        mock_backend.load.return_value = existing
         manager.load()
 
         assert manager._state["pages"]["docs/guide.md"]["page_id"] == "123"
-        assert manager._state["version"] == "1"
-
-    def test_load_raises_on_invalid_schema(self, state_path, manager):
-        """load() raises ValueError when state file has unexpected schema (line 38)."""
-        state_path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
-        with pytest.raises(ValueError, match="unexpected schema"):
-            manager.load()
+        mock_backend.load.assert_called_once()
 
 
 class TestSave:
-    def test_save_writes_json_to_disk(self, state_path, manager):
-        """save() writes state JSON via atomic rename (lines 40-42)."""
-        manager.set_page(
-            rel_path="docs/page.md",
-            page_id="p1",
-            title="Page",
-            space_key="DOCS",
-            space_id="s1",
-            content_hash="sha256:deadbeef",
-        )
+    def test_save_delegates_to_backend(self, manager, mock_backend):
+        """save() calls backend.save() with the current state."""
+        manager.set_page("docs/page.md", "p1", "Page", "DOCS", "s1", "sha256:deadbeef")
         manager.save()
 
-        assert state_path.exists()
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-        assert data["pages"]["docs/page.md"]["page_id"] == "p1"
-
-    def test_save_uses_atomic_rename(self, state_path, manager):
-        """Tmp file is cleaned up after rename (atomic write pattern)."""
-        manager.save()
-        tmp = state_path.with_suffix(".json.tmp")
-        # After save the tmp file must NOT exist (it was renamed)
-        assert not tmp.exists()
-        assert state_path.exists()
-
-    def test_save_is_sorted_keys(self, state_path, manager):
-        """save() uses sort_keys=True for deterministic output."""
-        manager.set_page("b.md", "2", "B", "DOCS", "s1", "sha256:00")
-        manager.set_page("a.md", "1", "A", "DOCS", "s1", "sha256:00")
-        manager.save()
-
-        raw = state_path.read_text(encoding="utf-8")
-        data = json.loads(raw)
-        keys = list(data["pages"].keys())
-        assert keys == sorted(keys)
+        mock_backend.save.assert_called_once()
+        saved_data = mock_backend.save.call_args[0][0]
+        assert saved_data["pages"]["docs/page.md"]["page_id"] == "p1"
 
 
 class TestGetPage:
     def test_get_page_returns_none_when_not_tracked(self, manager):
-        """get_page returns None for unknown paths (line 50)."""
         assert manager.get_page("docs/nonexistent.md") is None
 
     def test_get_page_returns_entry_when_tracked(self, manager):
@@ -115,7 +77,6 @@ class TestGetPage:
 
 class TestSetPage:
     def test_set_page_creates_entry(self, manager):
-        """set_page stores all expected fields (line 62)."""
         manager.set_page(
             rel_path="docs/new.md",
             page_id="99",
@@ -140,34 +101,53 @@ class TestSetPage:
 
 class TestRemovePage:
     def test_remove_page_deletes_tracked_entry(self, manager):
-        """remove_page pops the entry from pages (line 73)."""
         manager.set_page("docs/rm.md", "10", "Rm", "SP", "s", "sha256:x")
         manager.remove_page("docs/rm.md")
         assert manager.get_page("docs/rm.md") is None
 
     def test_remove_page_no_op_when_not_tracked(self, manager):
-        """remove_page is silent when the path is not in state."""
-        # Should not raise
         manager.remove_page("docs/ghost.md")
 
 
 class TestAllPages:
-    def test_all_pages_returns_shallow_copy(self, manager):
-        """all_pages returns a new dict (shallow copy) of the pages (line 78)."""
+    def test_all_pages_returns_copy(self, manager):
         manager.set_page("docs/a.md", "1", "A", "SP", "s", "sha256:a")
         pages = manager.all_pages
         assert "docs/a.md" in pages
-        # Adding a new key to the copy must NOT appear in the internal state
         pages["docs/extra.md"] = {"page_id": "999"}
         assert manager.get_page("docs/extra.md") is None
+
+    def test_all_pages_deep_copy_prevents_nested_mutation(self, manager):
+        manager.set_page("docs/a.md", "1", "A", "SP", "s", "sha256:a")
+        pages = manager.all_pages
+        pages["docs/a.md"]["page_id"] = "mutated"
+        assert manager.get_page("docs/a.md")["page_id"] == "1"
 
     def test_all_pages_empty_when_no_entries(self, manager):
         assert manager.all_pages == {}
 
 
+class TestRawState:
+    def test_raw_state_returns_full_dict(self, manager):
+        manager.set_page("docs/a.md", "1", "A", "SP", "s", "sha256:a")
+        raw = manager.raw_state
+        assert raw["version"] == StateManager.STATE_VERSION
+        assert "docs/a.md" in raw["pages"]
+
+    def test_raw_state_deep_copy_prevents_top_level_mutation(self, manager):
+        raw = manager.raw_state
+        raw["injected"] = True
+        assert "injected" not in manager.raw_state
+
+    def test_raw_state_deep_copy_prevents_nested_mutation(self, manager):
+        manager.set_page("docs/a.md", "1", "A", "SP", "s", "sha256:a")
+        raw = manager.raw_state
+        raw["pages"]["docs/a.md"]["page_id"] = "mutated"
+        assert manager.get_page("docs/a.md")["page_id"] == "1"
+
+
 class TestComputeHash:
     def test_compute_hash_returns_sha256_prefixed_hex(self, manager, tmp_path):
-        """compute_hash returns sha256:<hex> (lines 89-90)."""
         f = tmp_path / "sample.txt"
         f.write_bytes(b"hello world")
         expected = "sha256:" + hashlib.sha256(b"hello world").hexdigest()
@@ -183,13 +163,11 @@ class TestComputeHash:
 
 class TestHasChanged:
     def test_has_changed_true_when_not_tracked(self, manager, tmp_path):
-        """has_changed is True for untracked files (lines 95-97)."""
         f = tmp_path / "untracked.md"
         f.write_bytes(b"# Hello")
         assert manager.has_changed("docs/untracked.md", f) is True
 
     def test_has_changed_false_when_hash_matches(self, manager, tmp_path):
-        """has_changed is False when stored hash equals current hash (line 98)."""
         f = tmp_path / "same.md"
         f.write_bytes(b"# Content")
         current_hash = manager.compute_hash(f)
@@ -197,36 +175,26 @@ class TestHasChanged:
         assert manager.has_changed("docs/same.md", f) is False
 
     def test_has_changed_true_when_content_differs(self, manager, tmp_path):
-        """has_changed is True when stored hash differs from current hash."""
         f = tmp_path / "changed.md"
         f.write_bytes(b"# Old")
         old_hash = manager.compute_hash(f)
         manager.set_page("docs/changed.md", "1", "Changed", "SP", "s", old_hash)
-        # Overwrite with new content
         f.write_bytes(b"# New")
         assert manager.has_changed("docs/changed.md", f) is True
 
 
 class TestFindOrphans:
     def test_find_orphans_empty_when_all_files_present(self, manager, tmp_path):
-        """No orphans when all tracked files still exist on disk (lines 111-127).
-
-        find_orphans uses Path(rel_path).relative_to(docs_root) so docs_root must be
-        a relative path that matches the prefix of rel_path.
-        """
         docs = tmp_path / "docs"
         docs.mkdir()
         f = docs / "page.md"
         f.write_bytes(b"# Page")
 
-        import os
-
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            rel = str(f.relative_to(tmp_path))  # "docs/page.md"
+            rel = str(f.relative_to(tmp_path))
             manager.set_page(rel, "1", "Page", "SP", "s", "sha256:x")
-            # docs_root must be relative so Path(rel_path).relative_to(docs_root) works
             orphans = manager.find_orphans([f], Path("docs"))
         finally:
             os.chdir(old_cwd)
@@ -234,19 +202,15 @@ class TestFindOrphans:
         assert orphans == []
 
     def test_find_orphans_detects_deleted_file(self, manager, tmp_path):
-        """Orphan is returned for a tracked file no longer on disk."""
         docs = tmp_path / "docs"
         docs.mkdir()
         deleted = docs / "deleted.md"
 
-        import os
-
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            rel = str(deleted.relative_to(tmp_path))  # "docs/deleted.md"
+            rel = str(deleted.relative_to(tmp_path))
             manager.set_page(rel, "42", "Deleted", "SP", "s", "sha256:gone")
-            # Pass no current files — deleted.md is absent
             orphans = manager.find_orphans([], Path("docs"))
         finally:
             os.chdir(old_cwd)
@@ -254,21 +218,17 @@ class TestFindOrphans:
         assert rel in orphans
 
     def test_find_orphans_ignores_entries_outside_docs_root(self, manager, tmp_path):
-        """Pages tracked outside docs_root are not flagged as orphans."""
         docs = tmp_path / "docs"
         docs.mkdir()
         other = tmp_path / "other"
         other.mkdir()
 
-        import os
-
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
             other_file = other / "unrelated.md"
-            rel = str(other_file.relative_to(tmp_path))  # "other/unrelated.md"
+            rel = str(other_file.relative_to(tmp_path))
             manager.set_page(rel, "99", "Unrelated", "SP", "s", "sha256:xx")
-            # docs_root is "docs" — entry is under "other", not under "docs"
             orphans = manager.find_orphans([], Path("docs"))
         finally:
             os.chdir(old_cwd)
@@ -276,26 +236,17 @@ class TestFindOrphans:
         assert orphans == []
 
     def test_find_orphans_filepath_not_under_cwd_uses_absolute(self, manager, tmp_path):
-        """_to_rel falls back to absolute string when relative_to(cwd) raises ValueError."""
         docs = tmp_path / "docs"
         docs.mkdir()
         present = docs / "present.md"
         present.write_bytes(b"x")
 
-        import os
-
-        # Create a sibling directory guaranteed NOT to be an ancestor of tmp_path on
-        # any platform.  This avoids the Linux failure where /tmp is an ancestor of
-        # pytest's tmp_path (e.g. /tmp/pytest-of-runner/...).
         unrelated_cwd = tmp_path.parent / "unrelated_cwd_state"
         unrelated_cwd.mkdir(exist_ok=True)
 
         old_cwd = os.getcwd()
         os.chdir(unrelated_cwd)
         try:
-            # present is absolute and NOT relative to unrelated_cwd,
-            # so _to_rel returns str(present) instead of raising.
-            # "some/other.md" is not relative to Path("docs") so not flagged as orphan.
             manager.set_page("some/other.md", "7", "Other", "SP", "s", "sha256:x")
             orphans = manager.find_orphans([present], Path("docs"))
             assert orphans == []
@@ -303,9 +254,6 @@ class TestFindOrphans:
             os.chdir(old_cwd)
 
     def test_find_orphans_absolute_docs_root_under_cwd(self, manager, tmp_path):
-        """find_orphans works when docs_root is absolute but under cwd (lines 133-136)."""
-        import os
-
         docs = tmp_path / "docs"
         docs.mkdir()
 
@@ -314,7 +262,6 @@ class TestFindOrphans:
         try:
             rel = "docs/gone.md"
             manager.set_page(rel, "55", "Gone", "SP", "s", "sha256:x")
-            # Pass absolute docs_root that IS under cwd — normalises to "docs"
             orphans = manager.find_orphans([], docs.resolve())
         finally:
             os.chdir(old_cwd)
@@ -322,15 +269,24 @@ class TestFindOrphans:
         assert rel in orphans
 
     def test_find_orphans_absolute_docs_root_outside_cwd(self, manager):
-        """find_orphans falls back gracefully when absolute docs_root not under cwd (lines 135-136).
-
-        When docs_root cannot be made relative to cwd, it is used as-is. Stored
-        rel_paths (relative strings) cannot be relative_to an unrelated absolute
-        path, so they are silently skipped — no orphans are reported.
-        """
-        # Use a known absolute path that is definitely not under cwd
         abs_docs_root = Path("/tmp/totally-unrelated-dir")
         manager.set_page("docs/page.md", "1", "Page", "SP", "s", "sha256:x")
-        # Should not raise; returns [] because rel_path can't be relative to abs_docs_root
         orphans = manager.find_orphans([], abs_docs_root)
         assert orphans == []
+
+    def test_find_orphans_skips_directory_container_entries(self, manager, tmp_path):
+        """Non-.md entries (directory container pages) are never reported as orphans."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            # Add a directory container page (no .md extension) and a real md file
+            manager.set_page("docs/my-dir", "dir-id", "My Dir", "SP", "s", "")
+            manager.set_page("docs/page.md", "pg-id", "Page", "SP", "s", "sha256:x")
+            orphans = manager.find_orphans([], Path("docs"))
+        finally:
+            os.chdir(old_cwd)
+        # Only the .md file should be an orphan; the directory entry is skipped
+        assert "docs/my-dir" not in orphans
+        assert "docs/page.md" in orphans


### PR DESCRIPTION
## Summary

- **Remote state backend**: state is stored as a JSON attachment on the CCFM management page in Confluence via `ConfluenceBackend`. `StateManager` loads/saves through this backend, enabling changed-files-only deploys and orphan detection across runs.
- **Distributed locking**: `LockManager` uses Confluence content properties as an advisory lock on the management page. Deploy, `state rm`, and `state push` all acquire the lock before writing to prevent concurrent torn-state scenarios.
- **Extended CLI**: new subcommands `ccfm state pull/push/show` and `ccfm lock acquire` for operator recovery and inspection workflows.
- **`ccfm init`**: idempotent bootstrap subcommand that creates `_ccfm` container + `CCFM State Management` page.
- **HTTP resilience**: `requests.Session` with retry adapter (GET/PUT/DELETE only — POST excluded to prevent duplicate page creation on 5xx).
- **Hierarchy page tracking**: `ensure_page_hierarchy` now tracks container directory pages in state; `find_orphans` skips them.
- **Security hardening**: symlink escape guard, deep copies on `all_pages`/`raw_state`, `page_id` validation (`^[1-9]\d*$`, string type required), ANSI-sanitised + length-capped error output.
- **Smoke test overhaul**: teardown resets the state attachment instead of deleting management infrastructure; `_delete_all_children` recurses bottom-up.
- **README**: new Initial Setup section and full CLI reference for all subcommands.

## Test plan

- [x] All 551 unit tests pass at 100% coverage (`pytest tests/ --cov=src/ccfm_convert --cov-fail-under=100`)
- [x] `ccfm init` bootstraps management infrastructure idempotently
- [x] `ccfm deploy` acquires lock, deploys, releases lock; concurrent deploy blocked correctly
- [x] `ccfm state pull | jq .pages` outputs state JSON
- [x] `ccfm state push <file>` validates schema and page_id, acquires lock, overwrites remote state
- [x] `ccfm state rm <path>` acquires lock, removes entry, releases lock
- [x] `ccfm lock acquire` / `ccfm lock status` / `ccfm lock release` round-trip correctly
- [x] Smoke test teardown leaves `_ccfm` container and management page intact, state reset to empty