### PR TITLE
fix(deploy): --changed-only now deploys only changed files

### DIFF
--- a/src/ccfm_convert/deploy/orchestration.py
+++ b/src/ccfm_convert/deploy/orchestration.py
@@ -138,7 +138,7 @@ def ensure_page_hierarchy(api, space_id, filepath, docs_root, git_repo_url=""):
     return current_parent_id, hierarchy_pages
 
 
-def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False):
+def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False, files=None):
     """
     Deploy an entire directory tree.
 
@@ -149,13 +149,19 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
         docs_root: Root documentation directory
         git_repo_url: Git repository URL for CI banner
         dump: If True, write ADF JSON files and skip deployment
+        files: Optional pre-filtered list of files to deploy. When provided,
+            only these files are deployed instead of discovering all .md files
+            via rglob. Used by --changed-only to limit deployment scope.
 
     Returns:
         Tuple of (results, hierarchy_pages) where results is a list of
         (filepath, page_id) tuples and hierarchy_pages is a deduplicated list of
         (rel_path, page_id, title) for each directory container page.
     """
-    md_files = sorted(root_path.rglob("*.md"))
+    if files is not None:
+        md_files = sorted(files)
+    else:
+        md_files = sorted(root_path.rglob("*.md"))
 
     # Filter out .page_content.md files (these are used for container pages)
     md_files = [f for f in md_files if f.name != ".page_content.md"]

--- a/src/ccfm_convert/main.py
+++ b/src/ccfm_convert/main.py
@@ -302,7 +302,12 @@ def _handle_deploy(args, parser):
 
         elif hasattr(args, "directory") and args.directory:
             results, hierarchy_pages = deploy_tree(
-                api, space_id, args.directory, args.docs_root, git_repo_url
+                api,
+                space_id,
+                args.directory,
+                args.docs_root,
+                git_repo_url,
+                files=target_files if getattr(args, "changed_only", False) else None,
             )
             for h_rel_path, h_page_id, h_title in hierarchy_pages:
                 state.set_page(

--- a/tests/smoke/test_state_management.py
+++ b/tests/smoke/test_state_management.py
@@ -89,6 +89,11 @@ class TestChangedOnly:
                 f"Expected page-alpha to appear in --changed-only output.\n"
                 f"stdout: {result.stdout}"
             )
+            # Unchanged page-beta must NOT be deployed (issue #6)
+            assert "page-beta" not in result.stdout, (
+                f"Unchanged page-beta should NOT be deployed with --changed-only.\n"
+                f"stdout: {result.stdout}"
+            )
         finally:
             # Always restore the original content
             PAGE_ALPHA.write_text(original_content, encoding="utf-8")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1105,6 +1105,15 @@ class TestDeployChangedOnly:
         captured = capsys.readouterr()
         assert "--changed-only: 1 file(s) with changes" in captured.out
 
+        # deploy_tree must receive only the changed file via files= kwarg
+        mock_deploy_tree.assert_called_once()
+        call_kwargs = mock_deploy_tree.call_args
+        files_arg = call_kwargs[1].get("files") if call_kwargs[1] else None
+        assert files_arg is not None, "deploy_tree must be called with files= when --changed-only"
+        file_names = [f.name for f in files_arg]
+        assert "changed.md" in file_names
+        assert "unchanged.md" not in file_names
+
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -794,6 +794,64 @@ class TestPathTraversalProtection:
 class TestEdgeCases:
     """Test edge cases and error scenarios."""
 
+    def test_files_param_deploys_only_specified_files(self, mock_api, tmp_path):
+        """deploy_tree with files= deploys only the provided files, not all in directory."""
+        docs_root = tmp_path / "docs"
+        docs_root.mkdir()
+
+        file_a = docs_root / "alpha.md"
+        file_b = docs_root / "beta.md"
+        file_a.write_text("# Alpha")
+        file_b.write_text("# Beta")
+
+        mock_api.find_page_by_title.return_value = None
+        mock_api.create_page.return_value = "page-123"
+
+        # Only pass file_a — file_b should NOT be deployed
+        deploy_tree(mock_api, "space123", docs_root, docs_root, files=[file_a])
+
+        # Exactly one page created (alpha only)
+        assert mock_api.create_page.call_count == 1
+
+    def test_files_param_none_uses_rglob(self, mock_api, tmp_path):
+        """deploy_tree with files=None discovers all .md files via rglob."""
+        docs_root = tmp_path / "docs"
+        docs_root.mkdir()
+
+        (docs_root / "one.md").write_text("# One")
+        (docs_root / "two.md").write_text("# Two")
+
+        mock_api.find_page_by_title.return_value = None
+        mock_api.create_page.return_value = "page-123"
+
+        deploy_tree(mock_api, "space123", docs_root, docs_root, files=None)
+
+        # Both files discovered and deployed
+        assert mock_api.create_page.call_count == 2
+
+    def test_files_param_preserves_hierarchy(self, mock_api, tmp_path):
+        """deploy_tree with files= still creates parent pages for nested files."""
+        docs_root = tmp_path / "docs"
+        subdir = docs_root / "section"
+        subdir.mkdir(parents=True)
+
+        nested = subdir / "page.md"
+        nested.write_text("# Nested Page")
+
+        call_count = [0]
+
+        def mock_create(space_id, parent_id, title, body, status="current"):
+            call_count[0] += 1
+            return f"page-{call_count[0]}"
+
+        mock_api.create_page.side_effect = mock_create
+        mock_api.find_page_by_title.return_value = None
+
+        deploy_tree(mock_api, "space123", docs_root, docs_root, files=[nested])
+
+        # Should create container page for "section" + the actual page
+        assert mock_api.create_page.call_count == 2
+
     def test_empty_directory(self, mock_api, tmp_path):
         """Test deploying empty directory."""
         docs_root = tmp_path / "docs"


### PR DESCRIPTION
## Summary
- `deploy_tree()` was ignoring the `--changed-only` filtered file list and rediscovering all `.md` files via `rglob`
- Added a `files` parameter to `deploy_tree()` so the pre-filtered list flows through correctly
- Strengthened smoke test to assert unchanged pages are NOT deployed

Closes #6

## Test plan
- [x] Unit tests pass (554 passed, 100% coverage)
- [x] Smoke tests: run `test_changed_only_deploys_modified_file` against live Confluence to verify only the modified page is deployed
- [x] Manual CLI test: deploy a directory, modify one file, run `--changed-only` and confirm only the modified file is processed