### PR TITLE
feat(dump): add dump subcommand and refactor plan/apply workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# CCFM working directory (dumps, etc.)
+.ccfm/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/README.md
+++ b/README.md
@@ -78,35 +78,55 @@ This is **bold** text, this is *italic*.
 ::In Progress::blue::   ::Stable::green::
 ```
 
-### 5. Deploy
+### 5. Preview changes
 
 ```bash
-# Deploy a single file
+# See what would change without touching Confluence
 ccfm \
   --domain your-domain.atlassian.net \
   --email your.email@example.com \
   --token YOUR_API_TOKEN \
   --space YOUR_SPACE_KEY \
-  deploy --file path/to/my-page.md
-
-# Deploy a directory recursively
-ccfm \
-  --domain your-domain.atlassian.net \
-  --email your.email@example.com \
-  --token YOUR_API_TOKEN \
-  --space YOUR_SPACE_KEY \
-  deploy --directory path/to/docs
+  plan --directory path/to/docs
 ```
 
-### 6. Inspect before deploying
-
-Use `--dump` to write ADF JSON files locally without making any API calls:
+### 6. Apply changes
 
 ```bash
-ccfm deploy \
-  --file path/to/my-page.md \
-  --dump
-# Writes path/to/my-page.adf.json for inspection
+# Apply a single file
+ccfm \
+  --domain your-domain.atlassian.net \
+  --email your.email@example.com \
+  --token YOUR_API_TOKEN \
+  --space YOUR_SPACE_KEY \
+  apply --file path/to/my-page.md
+
+# Apply a directory recursively
+ccfm \
+  --domain your-domain.atlassian.net \
+  --email your.email@example.com \
+  --token YOUR_API_TOKEN \
+  --space YOUR_SPACE_KEY \
+  apply --directory path/to/docs
+
+# Skip confirmation prompt (for CI)
+ccfm apply --directory docs --auto-approve
+```
+
+### 7. Inspect ADF output
+
+Use the `dump` subcommand to convert markdown to ADF JSON files locally without making any
+API calls:
+
+```bash
+# Dump a single file (auto-creates .ccfm/dumps/<timestamp>/ output directory)
+ccfm dump --file path/to/my-page.md
+
+# Dump an entire directory
+ccfm dump --directory path/to/docs
+
+# Specify a custom output directory
+ccfm dump --directory path/to/docs --output-dir ./adf-output
 ```
 
 ---
@@ -151,7 +171,9 @@ ccfm [GLOBAL OPTIONS] <command> [COMMAND OPTIONS]
 
 Commands:
   init                   Initialise remote state in a Confluence space
-  deploy                 Deploy markdown files to Confluence
+  plan                   Preview what would change without making modifications
+  apply                  Apply changes to Confluence (add, change, destroy)
+  dump                   Convert markdown to ADF JSON files for inspection (no API calls)
   state list             List all pages tracked in remote state
   state pull             Print remote state JSON to stdout
   state push <file>      Overwrite remote state from a local file
@@ -169,25 +191,56 @@ Global options (apply to all commands):
   --space SPACE          Space key (e.g., DOCS — not the space display name)
 ```
 
-### Deploy options
+### Plan options
 
 ```text
-ccfm deploy [OPTIONS]
+ccfm plan [OPTIONS]
 
-Deployment targets (one required unless --dump):
-  --file PATH            Deploy a single markdown file
-  --directory PATH       Deploy a directory recursively
+Targets (one required):
+  --file PATH            Plan for a single markdown file
+  --directory PATH       Plan for a directory recursively
 
 Options:
   --docs-root PATH       Documentation root directory (default: docs)
   --git-repo-url URL     Git repo URL for CI banner source links
-  --dump                 Write ADF to .adf.json files, skip deployment
-  --plan                 Show what would be deployed without making changes
   --plan-exit-code       Exit 2 when plan detects pending changes (for CI gates)
-  --changed-only         Only deploy files whose content has changed
-  --archive-orphans      Archive pages for markdown files removed from disk
+  --force                Force re-deploy all files regardless of content changes
+```
+
+### Apply options
+
+```text
+ccfm apply [OPTIONS]
+
+Targets (one required):
+  --file PATH            Apply a single markdown file
+  --directory PATH       Apply a directory recursively
+
+Options:
+  --docs-root PATH       Documentation root directory (default: docs)
+  --git-repo-url URL     Git repo URL for CI banner source links
+  --auto-approve         Skip confirmation prompt (required for CI/non-interactive use)
+  --force                Force re-deploy all files regardless of content changes
   --lock-id ID           Lock identifier for CI traceability (e.g., pipeline ID)
 ```
+
+### Dump options
+
+```text
+ccfm dump [OPTIONS]
+
+Targets (one required):
+  --file PATH            Single markdown file to dump
+  --directory PATH       Directory to dump (recursive)
+
+Options:
+  --docs-root PATH       Root documentation directory (default: docs)
+  --git-repo-url URL     Git repo URL for CI banner
+  --output-dir PATH      Output directory for .adf.json files (default: .ccfm/dumps/<timestamp>/)
+```
+
+No credentials are needed — dump is a local-only operation. The output directory mirrors the
+source tree structure (e.g., `docs/team/api.md` becomes `<output-dir>/docs/team/api.adf.json`).
 
 ### Examples
 
@@ -195,20 +248,27 @@ Options:
 # Initialise CCFM in your space (one-time setup)
 ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS init
 
-# Deploy a single file
+# Preview what would change
 ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
-  deploy --file path/to/api/authentication.md
+  plan --directory path/to/docs
 
-# Deploy entire docs folder
+# Apply a single file (interactive prompt)
 ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
-  deploy --directory path/to/docs
+  apply --file path/to/api/authentication.md
+
+# Apply entire docs folder with auto-approve (for CI)
+ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
+  apply --directory path/to/docs --auto-approve
 
 # With CI banner links back to source files
 ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
-  deploy --directory path/to/docs --git-repo-url "https://github.com/org/repo/blob/main"
+  apply --directory path/to/docs --git-repo-url "https://github.com/org/repo/blob/main" --auto-approve
 
-# Preview changes without deploying (credentials from ccfm.yaml)
-ccfm deploy --directory docs --plan
+# Preview changes (credentials from ccfm.yaml)
+ccfm plan --directory docs
+
+# Force re-deploy all files
+ccfm apply --directory docs --force --auto-approve
 
 # Check lock status
 ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS \
@@ -229,22 +289,24 @@ page, which lives under a `_ccfm` container page in your space.
 
 This enables:
 
-- **Plan mode** — see what would change before deploying
-- **Changed-only deploys** — skip files with no content changes (faster CI)
-- **Orphan archiving** — archive pages whose source files have been deleted
+- **Plan mode** — see what would change before applying
+- **Change detection** — only deploy files whose content has changed (default behaviour)
+- **Destroy detection** — automatically destroy pages whose source files have been deleted
 - **No checkin loops** — state changes don't trigger CI rebuilds
 - **No merge conflicts** — concurrent deploys don't fight over a state file
 
 ### Initialising
 
-Run `ccfm init` before your first deploy. This creates the management infrastructure
+Run `ccfm init` before your first apply. This creates the management infrastructure
 in your Confluence space:
 
 ```bash
 ccfm --domain company.atlassian.net --email user@example.com --token abc123 --space DOCS init
 ```
 
-The command is idempotent — running it again is a no-op. It is a **one-time per-space** operation; you do not need to run it before every deploy.
+The command is idempotent — running it again is a no-op. It is a **one-time per-space** operation; you do not need to run it before every apply.
+
+> **Note:** All files inside your `docs_root` directory are managed by CCFM. Removing files or folders will result in destroy operations on the next `ccfm apply`.
 
 ### Inspecting and managing state
 
@@ -274,16 +336,24 @@ ccfm --domain ... --email ... --token ... --space DOCS state push state-backup.j
 
 > **Warning:** `state push` overwrites the remote state completely. Use with caution.
 
-### Plan mode
+### Plan and apply workflow
 
 Preview what would change without making any modifications:
 
 ```bash
-ccfm deploy --directory docs --plan
+ccfm plan --directory docs
 ```
 
-Use `--plan-exit-code` to exit with code `2` when there are pending changes — useful
-for CI gates that block merges until docs are deployed.
+Apply changes interactively (prompts for confirmation):
+
+```bash
+ccfm apply --directory docs
+```
+
+Use `--plan-exit-code` with `plan` to exit with code `2` when there are pending changes —
+useful for CI gates that block merges until docs are deployed.
+
+Use `--auto-approve` with `apply` to skip the confirmation prompt (required for CI).
 
 ---
 
@@ -295,9 +365,9 @@ using Confluence's optimistic concurrency (version numbers) to prevent race cond
 
 ### How it works
 
-- `ccfm deploy` automatically acquires a lock before deploying and releases it when done
-- If another deploy is in progress, the command fails immediately with a lock error
-- `--plan` and `--dump` modes do **not** acquire locks (they're read-only)
+- `ccfm apply` automatically acquires a lock before applying and releases it when done
+- If another apply is in progress, the command fails immediately with a lock error
+- `ccfm plan` and `ccfm dump` do **not** acquire locks (they're read-only)
 - Lock owner is auto-detected as `user@hostname`
 
 ### CI traceability
@@ -305,7 +375,7 @@ using Confluence's optimistic concurrency (version numbers) to prevent race cond
 Pass `--lock-id` to associate the lock with a CI pipeline for easier debugging:
 
 ```bash
-ccfm --space DOCS deploy --directory docs --lock-id "$CI_PIPELINE_ID"
+ccfm --space DOCS apply --directory docs --auto-approve --lock-id "$CI_PIPELINE_ID"
 ```
 
 ### Checking lock status
@@ -330,7 +400,7 @@ ccfm --domain ... --email ... --token ... --space DOCS \
 
 ### Recovering from stale locks
 
-If a CI job crashes mid-deploy, the lock may be left in place. Force-release it:
+If a CI job crashes mid-apply, the lock may be left in place. Force-release it:
 
 ```bash
 ccfm --domain ... --email ... --token ... --space DOCS lock release
@@ -357,8 +427,8 @@ git_repo_url: https://github.com/org/repo
 With a config file in place:
 
 ```bash
-ccfm deploy --directory docs --plan
-ccfm deploy --directory docs
+ccfm plan --directory docs
+ccfm apply --directory docs --auto-approve
 ```
 
 **Security note:** `ccfm.yaml` is a trusted-author file. Any environment variable
@@ -378,7 +448,7 @@ docker run --rm \
   -e CONFLUENCE_TOKEN=your-token \
   -v $(pwd)/docs:/docs \
   ghcr.io/stevesimpson418/ccfm-convert:latest \
-  deploy --space DOCS --directory /docs
+  apply --space DOCS --directory /docs --auto-approve
 ```
 
 ---
@@ -393,7 +463,7 @@ docker run --rm \
     token:  ${{ secrets.CONFLUENCE_TOKEN }}
     space:  DOCS
     directory: docs
-    args: --changed-only
+    args: --auto-approve
 ```
 
 ---
@@ -453,16 +523,16 @@ jobs:
             --space DOCS \
             init
 
-          # Deploy with lock ID for CI traceability
+          # Apply with auto-approve and lock ID for CI traceability
           ccfm \
             --domain "$CONFLUENCE_DOMAIN" \
             --email "$CONFLUENCE_EMAIL" \
             --token "$CONFLUENCE_TOKEN" \
             --space DOCS \
-            deploy \
+            apply \
             --directory docs \
             --git-repo-url "https://github.com/${{ github.repository }}/blob/main" \
-            --changed-only \
+            --auto-approve \
             --lock-id "${{ github.run_id }}"
 ```
 
@@ -509,7 +579,7 @@ custom titles.
 │       ├── deploy/               # Confluence API and deployment logic
 │       │   ├── api.py            # ConfluenceAPI class (REST v2 + v1 for attachments/properties)
 │       │   ├── frontmatter.py    # YAML frontmatter parsing
-│       │   ├── orchestration.py  # deploy_page(), deploy_tree(), archive_page()
+│       │   ├── orchestration.py  # deploy_page(), deploy_tree(), destroy_page()
 │       │   └── transforms.py     # CI banner, page link resolution, attachment media nodes
 │       ├── state/                # Remote state and locking
 │       │   ├── backend.py        # StateBackend protocol + ConfluenceBackend
@@ -659,8 +729,8 @@ Use the space **key** (e.g., `DOCS`), not the display name. The key appears in t
 The management page was not found in your space. Run `ccfm init` to create the `_ccfm`
 container and state management page.
 
-**Deploy blocked by lock**
-Another deploy is in progress (or a previous deploy crashed without releasing the lock).
+**Apply blocked by lock**
+Another apply is in progress (or a previous apply crashed without releasing the lock).
 Check the lock status and force-release if the lock is stale:
 
 ```bash
@@ -678,8 +748,8 @@ Ensure markdown files are under the directory passed to `--directory`. Directori
 page's title and content.
 
 **Debugging ADF output**
-Use `--dump` to write `.adf.json` files alongside each markdown file. Inspect these to verify
-the ADF structure before deploying to Confluence.
+Use `ccfm dump` to write `.adf.json` files to a dedicated output directory. Inspect these to
+verify the ADF structure before deploying to Confluence.
 
 ---
 

--- a/src/ccfm_convert/config/loader.py
+++ b/src/ccfm_convert/config/loader.py
@@ -88,8 +88,8 @@ def merge_config_with_args(config: dict, args: Namespace) -> Namespace:
 
     A CLI arg is considered explicitly set if its current value is not None.
     Config values fill in gaps left by unset (None) CLI args. Boolean flags
-    (--plan, --dump, --changed-only, --archive-orphans) are not in _CONFIG_TO_ARG
-    and are not overrideable from the config file.
+    (--auto-approve, --dump, --force, --plan-exit-code) are not in _CONFIG_TO_ARG
+    and are not overridable from the config file.
 
     The merged result is returned as a new Namespace.
     """

--- a/src/ccfm_convert/deploy/__init__.py
+++ b/src/ccfm_convert/deploy/__init__.py
@@ -2,7 +2,15 @@
 
 from .api import ConfluenceAPI
 from .frontmatter import parse_frontmatter
-from .orchestration import archive_page, deploy_page, deploy_tree, ensure_page_hierarchy
+from .orchestration import (
+    deploy_page,
+    deploy_tree,
+    destroy_page,
+    destroy_pages,
+    dump_page,
+    dump_tree,
+    ensure_page_hierarchy,
+)
 from .transforms import add_ci_banner, create_metadata_expand, resolve_page_links
 
 __all__ = [
@@ -14,5 +22,8 @@ __all__ = [
     "ensure_page_hierarchy",
     "deploy_tree",
     "deploy_page",
-    "archive_page",
+    "destroy_page",
+    "destroy_pages",
+    "dump_page",
+    "dump_tree",
 ]

--- a/src/ccfm_convert/deploy/api.py
+++ b/src/ccfm_convert/deploy/api.py
@@ -35,7 +35,6 @@ class ConfluenceAPI:
         adapter = HTTPAdapter(max_retries=_RETRY_STRATEGY)
         self._session = requests.Session()
         self._session.mount("https://", adapter)
-        self._session.mount("http://", adapter)
 
     def get_space_id(self, space_key):
         """Get space ID from space key."""

--- a/src/ccfm_convert/deploy/orchestration.py
+++ b/src/ccfm_convert/deploy/orchestration.py
@@ -138,7 +138,7 @@ def ensure_page_hierarchy(api, space_id, filepath, docs_root, git_repo_url=""):
     return current_parent_id, hierarchy_pages
 
 
-def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False, files=None):
+def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", files=None):
     """
     Deploy an entire directory tree.
 
@@ -148,10 +148,9 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
         root_path: Path to deploy (can be docs root or subfolder)
         docs_root: Root documentation directory
         git_repo_url: Git repository URL for CI banner
-        dump: If True, write ADF JSON files and skip deployment
         files: Optional pre-filtered list of files to deploy. When provided,
             only these files are deployed instead of discovering all .md files
-            via rglob. Used by --changed-only to limit deployment scope.
+            via rglob. Used by apply to limit deployment to actionable files.
 
     Returns:
         Tuple of (results, hierarchy_pages) where results is a list of
@@ -174,20 +173,15 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
 
     for filepath in md_files:
         try:
-            # Ensure page hierarchy exists
-            if not dump:
-                parent_id, h_pages = ensure_page_hierarchy(
-                    api, space_id, filepath, root_path, git_repo_url
-                )
-                for hp in h_pages:
-                    if hp[0] not in seen_dirs:
-                        all_hierarchy_pages.append(hp)
-                        seen_dirs.add(hp[0])
-            else:
-                parent_id = None
+            parent_id, h_pages = ensure_page_hierarchy(
+                api, space_id, filepath, root_path, git_repo_url
+            )
+            for hp in h_pages:
+                if hp[0] not in seen_dirs:
+                    all_hierarchy_pages.append(hp)
+                    seen_dirs.add(hp[0])
 
-            # Deploy the file
-            page_id = deploy_page(api, space_id, parent_id, filepath, git_repo_url, dump=dump)
+            page_id = deploy_page(api, space_id, parent_id, filepath, git_repo_url)
             results.append((filepath, page_id))
         except Exception as e:
             print(f"   ❌ Error: {e}")
@@ -197,13 +191,12 @@ def deploy_tree(api, space_id, root_path, docs_root, git_repo_url="", dump=False
     return results, all_hierarchy_pages
 
 
-def archive_page(api, page_id: str, title: str) -> bool:
-    """Delete an orphaned Confluence page (moves it to the site trash).
+def destroy_page(api, page_id: str, title: str) -> bool:
+    """Delete a Confluence page (moves it to the site trash).
 
     The Confluence Cloud v2 API does not support ``status: archived`` via the
     PUT pages endpoint (only ``CURRENT`` and ``DRAFT`` are accepted). Instead,
-    we use the v2 DELETE endpoint, which moves the page to the site trash and
-    is equivalent to the "Archive" action in the Confluence UI.
+    we use the v2 DELETE endpoint, which moves the page to the site trash.
 
     Used to clean up pages whose source markdown files have been deleted.
 
@@ -217,14 +210,37 @@ def archive_page(api, page_id: str, title: str) -> bool:
     """
     try:
         api.delete_page(page_id)
-        print(f"   🗄️  Archived page: '{title}' (ID: {page_id})")
+        print(f"   🗑️  Destroyed page: '{title}' (ID: {page_id})")
         return True
     except Exception as e:
-        print(f"   ⚠️  Could not archive '{title}' (ID: {page_id}): {e}")
+        print(f"   ⚠️  Could not destroy '{title}' (ID: {page_id}): {e}")
         return False
 
 
-def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", dump=False):
+def destroy_pages(api, state, destroy_actions) -> int:
+    """Execute destroy actions — delete pages and remove from state.
+
+    Actions are expected to be pre-sorted deepest-first by the planner
+    (children before parents) to avoid Confluence errors when deleting
+    parent pages with children.
+
+    Args:
+        api: ConfluenceAPI instance
+        state: StateManager instance
+        destroy_actions: list of DestroyAction objects (pre-sorted by planner)
+
+    Returns:
+        Number of successfully destroyed pages.
+    """
+    destroyed = 0
+    for action in destroy_actions:
+        if destroy_page(api, action.page_id, action.title):
+            state.remove_page(action.rel_path)
+            destroyed += 1
+    return destroyed
+
+
+def deploy_page(api, space_id, parent_id, filepath, git_repo_url=""):
     """
     Deploy a single markdown file to Confluence.
 
@@ -241,7 +257,6 @@ def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", dump=False)
         parent_id: Parent page ID (computed from folder hierarchy)
         filepath: Path to markdown file
         git_repo_url: Git repository URL for CI banner
-        dump: If True, write ADF JSON to .adf.json file and skip deployment
     """
     print(f"\n📄 Processing: {filepath.name}")
 
@@ -268,14 +283,6 @@ def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", dump=False)
 
     # Resolve internal Confluence page links
     body = resolve_page_links(body, api, space_id)
-
-    if dump:
-        # Write ADF JSON to a file for inspection
-        out = filepath.with_suffix(".adf.json")
-        out.write_text(json.dumps(body, indent=2))
-        print(f"   💾 ADF written to: {out}")
-        print("   (Skipping deployment — remove --dump to deploy)")
-        return None
 
     # Frontmatter parent override
     frontmatter_parent = metadata.get("parent")
@@ -375,3 +382,83 @@ def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", dump=False)
 
     print(f"   ✅ Success! Page ID: {page_id}")
     return page_id
+
+
+def dump_page(filepath, output_dir, git_repo_url=""):
+    """Convert a single markdown file to ADF and write to output directory.
+
+    No API calls are made. Page link resolution is skipped (requires API).
+
+    Args:
+        filepath: Path to markdown file
+        output_dir: Directory to write .adf.json files into
+        git_repo_url: Git repository URL for CI banner
+
+    Returns:
+        Path to the written .adf.json file, or None on error.
+    """
+    print(f"\n📄 Processing: {filepath.name}")
+
+    content = filepath.read_text()
+    metadata, markdown = parse_frontmatter(content)
+
+    if not metadata.get("deploy_page", True):
+        print("   ⏭️  Skipping: deploy_page is set to false")
+        return None
+
+    title = metadata.get("title", filepath.stem.replace("-", " ").title())
+    print(f"   Title: {title}")
+
+    file_git_url = f"{git_repo_url}/{filepath}" if git_repo_url else ""
+    body = convert(markdown)
+
+    if metadata.get("ci_banner", True):
+        custom_banner_text = metadata.get("ci_banner_text")
+        body = add_ci_banner(body, file_git_url, banner_text=custom_banner_text, metadata=metadata)
+
+    # Write ADF JSON preserving relative path structure
+    try:
+        rel_path = filepath.relative_to(Path.cwd())
+    except ValueError:
+        rel_path = Path(filepath.name)
+
+    out = output_dir / rel_path.with_suffix(".adf.json")
+    try:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(body, indent=2))
+        print(f"   💾 ADF written to: {out}")
+        return out
+    except OSError as e:
+        print(f"   ❌ Error writing {out}: {e}")
+        return None
+
+
+def dump_tree(root_path, docs_root, output_dir, git_repo_url=""):
+    """Convert all markdown files in a directory tree to ADF and write to output directory.
+
+    No API calls are made. This is a local-only operation for ADF inspection.
+
+    Args:
+        root_path: Path to the directory to scan
+        docs_root: Root documentation directory
+        output_dir: Directory to write .adf.json files into
+        git_repo_url: Git repository URL for CI banner
+
+    Returns:
+        List of output file paths (None entries for failures).
+    """
+    md_files = sorted(root_path.rglob("*.md"))
+    md_files = [f for f in md_files if f.name != ".page_content.md"]
+
+    print(f"\n📚 Found {len(md_files)} markdown files in tree")
+
+    results: list[Path | None] = []
+    for filepath in md_files:
+        try:
+            out = dump_page(filepath, output_dir, git_repo_url)
+            results.append(out)
+        except Exception as e:
+            print(f"   ❌ Error: {e}")
+            results.append(None)
+
+    return results

--- a/src/ccfm_convert/main.py
+++ b/src/ccfm_convert/main.py
@@ -5,14 +5,18 @@ import json
 import os
 import re
 import sys
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 from ccfm_convert.config import load_config, merge_config_with_args
 from ccfm_convert.deploy import (
     ConfluenceAPI,
-    archive_page,
     deploy_page,
     deploy_tree,
+    destroy_pages,
+    dump_page,
+    dump_tree,
     ensure_page_hierarchy,
 )
 from ccfm_convert.deploy.frontmatter import parse_frontmatter
@@ -66,56 +70,72 @@ def _add_global_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--space", default=None, help="Space key")
 
 
+def _add_target_args(parser: argparse.ArgumentParser) -> None:
+    """Add --file, --directory, --docs-root, --git-repo-url shared by plan and apply."""
+    parser.add_argument("--file", type=Path, help="Single markdown file to target")
+    parser.add_argument("--directory", type=Path, help="Directory to target (recursive)")
+    parser.add_argument(
+        "--docs-root",
+        type=Path,
+        default=None,
+        help="Root documentation directory (default: docs)",
+    )
+    parser.add_argument("--git-repo-url", default="", help="Git repo URL for CI banner")
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Deploy markdown to Confluence Cloud")
     _add_global_args(parser)
 
     subparsers = parser.add_subparsers(dest="command")
 
-    # -- deploy ----------------------------------------------------------
-    deploy_parser = subparsers.add_parser("deploy", help="Deploy markdown to Confluence")
-    deploy_parser.add_argument("--file", type=Path, help="Single markdown file to deploy")
-    deploy_parser.add_argument("--directory", type=Path, help="Directory to deploy (recursive)")
-    deploy_parser.add_argument(
-        "--docs-root",
-        type=Path,
-        default=None,
-        help="Root documentation directory (default: docs)",
-    )
-    deploy_parser.add_argument("--git-repo-url", default="", help="Git repo URL for CI banner")
-    deploy_parser.add_argument(
-        "--dump",
-        action="store_true",
-        help="Write ADF to .adf.json files and skip deployment",
-    )
-    deploy_parser.add_argument(
-        "--plan",
-        action="store_true",
-        help="Show what would be deployed without making any changes",
-    )
-    deploy_parser.add_argument(
+    # -- init ------------------------------------------------------------
+    subparsers.add_parser("init", help="Initialize remote state infrastructure in the space")
+
+    # -- plan ------------------------------------------------------------
+    plan_parser = subparsers.add_parser("plan", help="Show what ccfm would do without applying")
+    _add_target_args(plan_parser)
+    plan_parser.add_argument(
         "--plan-exit-code",
         action="store_true",
-        help="With --plan, exit 2 when changes are pending (Terraform-style)",
+        help="Exit 2 when changes are pending (useful for CI gating)",
     )
-    deploy_parser.add_argument(
-        "--changed-only",
+    plan_parser.add_argument(
+        "--force",
         action="store_true",
-        help="Only deploy files whose content has changed since last deploy",
+        help="Treat all files as new (force re-deploy on next apply)",
     )
-    deploy_parser.add_argument(
-        "--archive-orphans",
+
+    # -- apply -----------------------------------------------------------
+    apply_parser = subparsers.add_parser("apply", help="Apply changes to Confluence")
+    _add_target_args(apply_parser)
+    apply_parser.add_argument(
+        "--auto-approve",
         action="store_true",
-        help="Archive Confluence pages for markdown files that no longer exist on disk",
+        help="Skip interactive confirmation prompt (for CI/CD)",
     )
-    deploy_parser.add_argument(
+    apply_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force re-deploy of all files regardless of state",
+    )
+    apply_parser.add_argument(
         "--lock-id",
         default=None,
         help="Lock identifier for CI traceability (default: user@hostname)",
     )
 
-    # -- init ------------------------------------------------------------
-    subparsers.add_parser("init", help="Initialize remote state infrastructure in the space")
+    # -- dump ------------------------------------------------------------
+    dump_parser = subparsers.add_parser(
+        "dump", help="Convert markdown to ADF JSON files for inspection (no API calls)"
+    )
+    _add_target_args(dump_parser)
+    dump_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory for .adf.json files (default: .ccfm/dumps/<timestamp>/)",
+    )
 
     # -- state -----------------------------------------------------------
     state_parser = subparsers.add_parser("state", help="Inspect or modify remote state")
@@ -185,6 +205,24 @@ def _find_management_page(api, space_id):
     return page_id
 
 
+def _resolve_target_files(args):
+    """Resolve target files from --file or --directory. Returns list of paths or exits."""
+    if hasattr(args, "file") and args.file:
+        if not args.file.exists():
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+        return [args.file]
+    elif hasattr(args, "directory") and args.directory:
+        if not args.directory.exists():
+            print(f"Error: Directory not found: {args.directory}", file=sys.stderr)
+            sys.exit(1)
+        all_md = sorted(args.directory.rglob("*.md"))
+        return [f for f in all_md if f.name != ".page_content.md"]
+    else:
+        print("Error: Specify either --file or --directory")
+        sys.exit(1)
+
+
 # ======================================================================
 # Subcommand handlers
 # ======================================================================
@@ -198,160 +236,181 @@ def _handle_init(args, parser):
     space_id = api.get_space_id(args.space)
     init_remote_state(api, args.space, space_id)
     print("\nInitialization complete!")
+    print("\nAll files inside your docs_root directory will be managed by ccfm.")
+    print("Removing files or folders will result in destroy operations on the next apply.")
 
 
-def _handle_deploy(args, parser):
-    """Handle the 'deploy' subcommand."""
-    # Apply deploy-specific defaults
+def _handle_plan(args, parser):
+    """Handle the 'plan' subcommand."""
     if not hasattr(args, "docs_root") or args.docs_root is None:
         args.docs_root = Path("docs")
 
-    # Resolve target files
-    if hasattr(args, "file") and args.file:
-        target_files = [args.file]
-    elif hasattr(args, "directory") and args.directory:
-        all_md = sorted(args.directory.rglob("*.md"))
-        target_files = [f for f in all_md if f.name != ".page_content.md"]
-    else:
-        print("Error: Specify either --file or --directory")
-        sys.exit(1)
+    target_files = _resolve_target_files(args)
 
-    # Snapshot all files before --changed-only filtering (for orphan detection)
-    all_files = list(target_files)
-
-    # --dump mode: no API, no state, no lock
-    if hasattr(args, "dump") and args.dump:
-        print("Dump mode — ADF will be written to .adf.json files, no deployment")
-        git_repo_url = getattr(args, "git_repo_url", "")
-        if hasattr(args, "file") and args.file:
-            deploy_page(None, None, None, args.file, git_repo_url, dump=True)
-        elif hasattr(args, "directory") and args.directory:
-            deploy_tree(None, None, args.directory, args.docs_root, git_repo_url, dump=True)
-        return
-
-    # All non-dump paths need credentials and API
     _require_credentials(args, parser)
     api = _create_api(args)
     print(f"Looking up space: {args.space}")
     space_id = api.get_space_id(args.space)
     print(f"   Space ID: {space_id}")
 
-    # Find management page for state + locking
     mgmt_page_id = _find_management_page(api, space_id)
     backend = ConfluenceBackend(api, mgmt_page_id)
     state = StateManager(backend)
     state.load()
 
-    # --plan mode: read-only, no lock needed
-    if hasattr(args, "plan") and args.plan:
-        plan = compute_plan(
-            state=state,
-            files=target_files,
-            docs_root=args.docs_root,
-            archive_orphans=getattr(args, "archive_orphans", False),
-        )
-        plan.print_summary()
-        if getattr(args, "plan_exit_code", False):
-            sys.exit(2 if plan.has_changes() else 0)
-        sys.exit(0)
+    force = getattr(args, "force", False)
+    plan = compute_plan(state=state, files=target_files, docs_root=args.docs_root, force=force)
+    plan.print_summary()
 
-    # --changed-only filter
-    if getattr(args, "changed_only", False):
-        target_files = [f for f in target_files if state.has_changed(_rel_path(f), f)]
-        print(f"--changed-only: {len(target_files)} file(s) with changes")
-        if not target_files:
-            print("No changes to deploy.")
+    if getattr(args, "plan_exit_code", False):
+        sys.exit(2 if plan.has_changes() else 0)
+
+
+def _handle_dump(args, parser):
+    """Handle the 'dump' subcommand."""
+    if not hasattr(args, "docs_root") or args.docs_root is None:
+        args.docs_root = Path("docs")
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    output_dir = args.output_dir or Path(".ccfm") / "dumps" / f"{timestamp}_{uuid.uuid4().hex[:8]}"
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        print(f"Error: Cannot create output directory '{output_dir}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    git_repo_url = getattr(args, "git_repo_url", "")
+
+    if hasattr(args, "file") and args.file:
+        if not args.file.exists():
+            parser.error(f"File not found: {args.file}")
+        dump_page(args.file, output_dir, git_repo_url)
+    elif hasattr(args, "directory") and args.directory:
+        if not args.directory.exists():
+            parser.error(f"Directory not found: {args.directory}")
+        dump_tree(args.directory, args.docs_root, output_dir, git_repo_url)
+    else:
+        print("Error: Specify either --file or --directory")
+        sys.exit(1)
+
+    print(f"\nDump complete! ADF files written to: {output_dir}")
+
+
+def _handle_apply(args, parser):
+    """Handle the 'apply' subcommand."""
+    if not hasattr(args, "docs_root") or args.docs_root is None:
+        args.docs_root = Path("docs")
+
+    target_files = _resolve_target_files(args)
+
+    _require_credentials(args, parser)
+    api = _create_api(args)
+    print(f"Looking up space: {args.space}")
+    space_id = api.get_space_id(args.space)
+    print(f"   Space ID: {space_id}")
+
+    mgmt_page_id = _find_management_page(api, space_id)
+    backend = ConfluenceBackend(api, mgmt_page_id)
+    state = StateManager(backend)
+    state.load()
+
+    # Compute plan
+    force = getattr(args, "force", False)
+    plan = compute_plan(state=state, files=target_files, docs_root=args.docs_root, force=force)
+    plan.print_summary()
+
+    if not plan.has_changes():
+        print("No changes to apply.")
+        return
+
+    # Confirmation prompt
+    auto_approve = getattr(args, "auto_approve", False)
+    if not auto_approve:
+        if not sys.stdin.isatty():
+            print(
+                "Error: apply requires confirmation. Use --auto-approve for non-interactive mode."
+            )
+            sys.exit(1)
+        answer = input("\nDo you want to apply these changes? Only 'yes' will be accepted: ")
+        if answer.strip().lower() != "yes":
+            print("Apply cancelled.")
             return
 
-    # Acquire lock for live deployment
+    # Acquire lock
     lock_mgr = LockManager(api, mgmt_page_id)
     lock_id = getattr(args, "lock_id", None)
     try:
-        lock_mgr.acquire(operation="deploy", lock_id=lock_id)
+        lock_mgr.acquire(operation="apply", lock_id=lock_id)
     except LockError as e:
         print(f"Error: {e}")
         sys.exit(1)
 
     git_repo_url = getattr(args, "git_repo_url", "")
     try:
-        # Live deployment
-        if hasattr(args, "file") and args.file:
-            parent_id, hierarchy_pages = ensure_page_hierarchy(
-                api, space_id, args.file, args.docs_root, git_repo_url
-            )
-            page_id = deploy_page(api, space_id, parent_id, args.file, git_repo_url)
-            for h_rel_path, h_page_id, h_title in hierarchy_pages:
-                state.set_page(
-                    rel_path=h_rel_path,
-                    page_id=h_page_id,
-                    title=h_title,
-                    space_key=args.space,
-                    space_id=space_id,
-                    content_hash="",
+        # Execute adds/changes
+        actionable = [a for a in plan.page_actions if a.action != "no-op"]
+        if actionable:
+            actionable_files = [a.filepath for a in actionable]
+            if hasattr(args, "file") and args.file:
+                target = actionable_files[0]
+                parent_id, hierarchy_pages = ensure_page_hierarchy(
+                    api, space_id, target, args.docs_root, git_repo_url
                 )
-            if page_id:
-                state.set_page(
-                    rel_path=_rel_path(args.file),
-                    page_id=page_id,
-                    title=_derive_title(args.file),
-                    space_key=args.space,
-                    space_id=space_id,
-                    content_hash=state.compute_hash(args.file),
-                )
-            state.save()
-
-        elif hasattr(args, "directory") and args.directory:
-            results, hierarchy_pages = deploy_tree(
-                api,
-                space_id,
-                args.directory,
-                args.docs_root,
-                git_repo_url,
-                files=target_files if getattr(args, "changed_only", False) else None,
-            )
-            for h_rel_path, h_page_id, h_title in hierarchy_pages:
-                state.set_page(
-                    rel_path=h_rel_path,
-                    page_id=h_page_id,
-                    title=h_title,
-                    space_key=args.space,
-                    space_id=space_id,
-                    content_hash="",
-                )
-            for filepath, page_id in results:
-                if page_id:
+                page_id = deploy_page(api, space_id, parent_id, target, git_repo_url)
+                for h_rel_path, h_page_id, h_title in hierarchy_pages:
                     state.set_page(
-                        rel_path=_rel_path(filepath),
-                        page_id=page_id,
-                        title=_derive_title(filepath),
+                        rel_path=h_rel_path,
+                        page_id=h_page_id,
+                        title=h_title,
                         space_key=args.space,
                         space_id=space_id,
-                        content_hash=state.compute_hash(filepath),
+                        content_hash="",
                     )
-            state.save()
+                if page_id:
+                    state.set_page(
+                        rel_path=_rel_path(target),
+                        page_id=page_id,
+                        title=_derive_title(target),
+                        space_key=args.space,
+                        space_id=space_id,
+                        content_hash=state.compute_hash(target),
+                    )
+            elif hasattr(args, "directory") and args.directory:
+                results, hierarchy_pages = deploy_tree(
+                    api,
+                    space_id,
+                    args.directory,
+                    args.docs_root,
+                    git_repo_url,
+                    files=actionable_files,
+                )
+                for h_rel_path, h_page_id, h_title in hierarchy_pages:
+                    state.set_page(
+                        rel_path=h_rel_path,
+                        page_id=h_page_id,
+                        title=h_title,
+                        space_key=args.space,
+                        space_id=space_id,
+                        content_hash="",
+                    )
+                for filepath, page_id in results:
+                    if page_id:
+                        state.set_page(
+                            rel_path=_rel_path(filepath),
+                            page_id=page_id,
+                            title=_derive_title(filepath),
+                            space_key=args.space,
+                            space_id=space_id,
+                            content_hash=state.compute_hash(filepath),
+                        )
 
-        # Archive orphaned pages
-        if getattr(args, "archive_orphans", False):
-            orphans = state.find_orphans(all_files, args.docs_root)
-            if orphans:
-                print(f"\nArchiving {len(orphans)} orphaned page(s)...")
-                archived_any = False
-                for rel_path in orphans:
-                    entry = state.get_page(rel_path)
-                    if entry:
-                        success = archive_page(api, entry["page_id"], entry["title"])
-                        if success:
-                            state.remove_page(rel_path)
-                            archived_any = True
-                if archived_any:
-                    # If save() throws here, in-memory state has orphans removed but
-                    # remote state has not been updated. Re-run --archive-orphans to
-                    # retry. The lock will be released normally by the outer finally.
-                    state.save()
-            else:
-                print("\nNo orphaned pages found.")
+        # Execute destroys
+        if plan.destroy_actions:
+            print(f"\nDestroying {len(plan.destroy_actions)} page(s)...")
+            destroy_pages(api, state, plan.destroy_actions)
 
-        print("\nDeployment complete!")
+        state.save()
+        print("\nApply complete!")
     finally:
         lock_mgr.release()
 
@@ -503,8 +562,12 @@ def main():
     # Route to subcommand handler
     if args.command == "init":
         _handle_init(args, parser)
-    elif args.command == "deploy":
-        _handle_deploy(args, parser)
+    elif args.command == "plan":
+        _handle_plan(args, parser)
+    elif args.command == "apply":
+        _handle_apply(args, parser)
+    elif args.command == "dump":
+        _handle_dump(args, parser)
     elif args.command == "state":
         _handle_state(args, parser)
     elif args.command == "lock":

--- a/src/ccfm_convert/plan/__init__.py
+++ b/src/ccfm_convert/plan/__init__.py
@@ -1,5 +1,5 @@
 """Deploy plan computation (diff/dry-run mode)."""
 
-from .planner import DeployPlan, OrphanAction, PageAction, compute_plan
+from .planner import DeployPlan, DestroyAction, PageAction, compute_plan
 
-__all__ = ["DeployPlan", "OrphanAction", "PageAction", "compute_plan"]
+__all__ = ["DeployPlan", "DestroyAction", "PageAction", "compute_plan"]

--- a/src/ccfm_convert/plan/planner.py
+++ b/src/ccfm_convert/plan/planner.py
@@ -1,10 +1,10 @@
 """Deploy plan computation — show what CCFM would do without deploying.
 
 Usage:
-    plan = compute_plan(state, files, docs_root, archive_orphans=True)
+    plan = compute_plan(state, files, docs_root)
     plan.print_summary()
     if plan.has_changes():
-        # proceed with deploy
+        # proceed with apply
 """
 
 from dataclasses import dataclass, field
@@ -21,82 +21,77 @@ class PageAction:
 
     filepath: Path
     rel_path: str
-    action: Literal["CREATE", "UPDATE", "NO_OP"]
+    action: Literal["add", "change", "no-op"]
     title: str
     current_hash: str
     stored_hash: str | None = None
-    page_id: str | None = None  # None for CREATE actions
+    page_id: str | None = None  # None for add actions
 
 
 @dataclass
-class OrphanAction:
-    """A planned archive action for a page whose source file no longer exists."""
+class DestroyAction:
+    """A planned destroy action for a page whose source file no longer exists."""
 
     rel_path: str
     page_id: str
     title: str
-    action: Literal["ARCHIVE"] = field(default="ARCHIVE")
+    action: Literal["destroy"] = field(default="destroy")
 
 
 @dataclass
 class DeployPlan:
-    """The complete set of actions CCFM would take on the next deploy."""
+    """The complete set of actions CCFM would take on the next apply."""
 
     page_actions: list[PageAction] = field(default_factory=list)
-    orphan_actions: list[OrphanAction] = field(default_factory=list)
+    destroy_actions: list[DestroyAction] = field(default_factory=list)
 
     def has_changes(self) -> bool:
-        """Return True if any deployable action exists (excludes NO_OP)."""
-        return any(a.action != "NO_OP" for a in self.page_actions) or bool(self.orphan_actions)
+        """Return True if any deployable action exists (excludes no-op)."""
+        return any(a.action != "no-op" for a in self.page_actions) or bool(self.destroy_actions)
 
     def print_summary(self) -> None:
         """Print a terraform-style plan summary to stdout."""
-        _SYMBOLS = {"CREATE": "+", "UPDATE": "~", "NO_OP": "·"}
-        _LABELS = {"CREATE": "CREATE ", "UPDATE": "UPDATE ", "NO_OP": "NO-OP  "}
+        _SYMBOLS = {"add": "+", "change": "~"}
 
-        print("\nCCFM Deploy Plan")
-        print("═" * 60)
-        print()
+        actionable = [a for a in self.page_actions if a.action != "no-op"]
+        has_any = bool(actionable) or bool(self.destroy_actions)
 
-        all_actions: list[PageAction | OrphanAction] = [
-            *self.page_actions,
-            *self.orphan_actions,
-        ]
-
-        if not all_actions:
-            print("  No files found to deploy.")
+        if not has_any:
+            no_ops = sum(1 for a in self.page_actions if a.action == "no-op")
+            if no_ops:
+                print("\nNo changes. Your Confluence pages are up to date.")
+            else:
+                print("\nNo files found to process.")
             print()
             return
 
-        for action in self.page_actions:
+        print("\nccfm will perform the following actions:\n")
+
+        for action in actionable:
             symbol = _SYMBOLS[action.action]
-            label = _LABELS[action.action]
-            print(f'  {symbol} {action.rel_path:<45} {label}  "{action.title}"')
+            label = f"({action.action})"
+            print(f'  {symbol} {action.rel_path:<40} {label:<12} "{action.title}"')
 
-        for orphan in self.orphan_actions:
-            print(f'  - {orphan.rel_path:<45} ARCHIVE  "{orphan.title}"  (file removed)')
+        for destroy in self.destroy_actions:
+            print(f'  - {destroy.rel_path:<40} {"(destroy)":<12} "{destroy.title}"')
 
-        creates = sum(1 for a in self.page_actions if a.action == "CREATE")
-        updates = sum(1 for a in self.page_actions if a.action == "UPDATE")
-        no_ops = sum(1 for a in self.page_actions if a.action == "NO_OP")
-        archives = len(self.orphan_actions)
+        adds = sum(1 for a in self.page_actions if a.action == "add")
+        changes = sum(1 for a in self.page_actions if a.action == "change")
+        no_ops = sum(1 for a in self.page_actions if a.action == "no-op")
+        destroys = len(self.destroy_actions)
 
         parts = []
-        if creates:
-            parts.append(f"{creates} to create")
-        if updates:
-            parts.append(f"{updates} to update")
-        if archives:
-            parts.append(f"{archives} to archive")
+        if adds:
+            parts.append(f"{adds} to add")
+        if changes:
+            parts.append(f"{changes} to change")
+        if destroys:
+            parts.append(f"{destroys} to destroy")
         if no_ops:
             parts.append(f"{no_ops} unchanged")
 
         print()
         print(f"Plan: {', '.join(parts)}.")
-
-        if self.has_changes():
-            print()
-            print("Run without --plan to apply.")
         print()
 
 
@@ -117,17 +112,17 @@ def compute_plan(
     state: StateManager,
     files: list[Path],
     docs_root: Path,
-    archive_orphans: bool = False,
+    force: bool = False,
 ) -> DeployPlan:
     """Compute the full deploy plan by comparing files on disk against stored state.
 
     Each file is classified as:
-      CREATE  — no state entry exists (never deployed)
-      UPDATE  — state exists but content hash has changed
-      NO_OP   — state exists and hash is unchanged
+      add     — no state entry exists (never deployed), or force=True
+      change  — state exists but content hash has changed
+      no-op   — state exists and hash is unchanged
 
-    If archive_orphans is True, files tracked in state but absent from disk are
-    added as ARCHIVE actions.
+    Files tracked in state but absent from disk are added as destroy actions.
+    Directory container pages are also destroyed when no files remain under them.
     """
     plan = DeployPlan()
 
@@ -143,12 +138,12 @@ def compute_plan(
         entry = state.get_page(rel_path)
         title = _derive_title(filepath)
 
-        if entry is None:
+        if force or entry is None:
             plan.page_actions.append(
                 PageAction(
                     filepath=filepath,
                     rel_path=rel_path,
-                    action="CREATE",
+                    action="add",
                     title=title,
                     current_hash=current_hash,
                 )
@@ -158,7 +153,7 @@ def compute_plan(
                 PageAction(
                     filepath=filepath,
                     rel_path=rel_path,
-                    action="UPDATE",
+                    action="change",
                     title=title,
                     current_hash=current_hash,
                     stored_hash=entry["content_hash"],
@@ -170,7 +165,7 @@ def compute_plan(
                 PageAction(
                     filepath=filepath,
                     rel_path=rel_path,
-                    action="NO_OP",
+                    action="no-op",
                     title=title,
                     current_hash=current_hash,
                     stored_hash=entry["content_hash"],
@@ -178,16 +173,41 @@ def compute_plan(
                 )
             )
 
-    if archive_orphans:
-        for rel_path in state.find_orphans(files, docs_root):
-            entry = state.get_page(rel_path)
-            if entry:
-                plan.orphan_actions.append(
-                    OrphanAction(
-                        rel_path=rel_path,
-                        page_id=entry["page_id"],
-                        title=entry["title"],
-                    )
+    # Destroy detection — always on
+    # 1. Orphaned .md files (in state but not on disk)
+    for rel_path in state.find_orphans(files, docs_root):
+        entry = state.get_page(rel_path)
+        if entry:
+            plan.destroy_actions.append(
+                DestroyAction(
+                    rel_path=rel_path,
+                    page_id=entry["page_id"],
+                    title=entry["title"],
                 )
+            )
+
+    # 2. Orphaned directory containers (content_hash == "", no .md files remain under them)
+    current_rel_paths = {a.rel_path for a in plan.page_actions}
+    all_pages = state.all_pages
+    for rel_path, entry in all_pages.items():
+        if rel_path.endswith(".md"):
+            continue
+        if entry.get("content_hash") != "":
+            continue
+        # Check if any tracked .md file still exists under this directory
+        has_children = any(
+            child_path.startswith(rel_path + "/") for child_path in current_rel_paths
+        )
+        if not has_children:
+            plan.destroy_actions.append(
+                DestroyAction(
+                    rel_path=rel_path,
+                    page_id=entry["page_id"],
+                    title=entry["title"],
+                )
+            )
+
+    # Sort destroys deepest-first (children before parents)
+    plan.destroy_actions.sort(key=lambda a: a.rel_path.count("/"), reverse=True)
 
     return plan

--- a/src/ccfm_convert/state/manager.py
+++ b/src/ccfm_convert/state/manager.py
@@ -62,7 +62,7 @@ class StateManager:
         }
 
     def remove_page(self, rel_path: str) -> None:
-        """Remove a page entry (called after archiving an orphaned page)."""
+        """Remove a page entry (called after destroying a page)."""
         self._state["pages"].pop(rel_path, None)
 
     @property
@@ -107,8 +107,8 @@ class StateManager:
         """Return relative paths that are tracked in state but have no corresponding
         file on disk within docs_root.
 
-        An orphan means the markdown source was deleted — the Confluence page may
-        need to be archived.
+        An orphan means the markdown source was deleted — the Confluence page will
+        be destroyed on the next ``ccfm apply``.
 
         docs_root may be absolute or relative; it is normalised to a relative path
         from cwd so comparisons against stored rel_paths are consistent.

--- a/tests/smoke/MANUAL_TESTING.md
+++ b/tests/smoke/MANUAL_TESTING.md
@@ -1,0 +1,144 @@
+# CCFM Manual Testing Runbook
+
+Step-by-step manual testing procedure for major feature releases.
+Run through these phases in order — each phase builds on the previous one.
+
+## Prerequisites
+
+1. Editable install: `pip install -e .`
+2. Credentials configured in `.env.smoke` or `ccfm-smoke.yaml`
+3. Source credentials: `source .env.smoke`
+4. Clean state: `ccfm --config tests/smoke/ccfm-smoke.yaml state list` should show no pages
+
+> If state is not clean, use `state rm` or reset via `state push` with an empty state file.
+
+---
+
+## Phase 1: Verify CLI Help
+
+Verify all subcommands print help and exit 0.
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 1.1 | `ccfm --help` | Shows all subcommands (init, plan, apply, dump, state, lock) | |
+| 1.2 | `ccfm init --help` | Shows init options | |
+| 1.3 | `ccfm plan --help` | Shows `--file`, `--directory`, `--plan-exit-code`, `--force` | |
+| 1.4 | `ccfm apply --help` | Shows `--auto-approve`, `--force`, `--lock-id` | |
+| 1.5 | `ccfm dump --help` | Shows `--file`, `--directory`, `--output-dir` | |
+| 1.6 | `ccfm state --help` | Shows list, pull, push, rm, show | |
+| 1.7 | `ccfm lock --help` | Shows status, acquire, release | |
+
+---
+
+## Phase 2: Plan
+
+```bash
+CFG="--config tests/smoke/ccfm-smoke.yaml"
+```
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 2.1 | `ccfm $CFG plan` | Error: "Specify either --file or --directory" | |
+| 2.2 | `ccfm $CFG plan --file tests/smoke/docs/single-page/single-page.md` | "Plan: 1 to add." | |
+| 2.3 | `ccfm $CFG plan --directory tests/smoke/docs` | "Plan: 7 to add." | |
+| 2.4 | `ccfm $CFG plan --directory tests/smoke/docs --plan-exit-code; echo $?` | Exit code 2 | |
+
+---
+
+## Phase 3: Apply
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 3.1 | `ccfm $CFG apply --file tests/smoke/docs/single-page/single-page.md` | Prompts for "yes", creates page on "yes" | |
+| 3.2 | Repeat 3.1 | "No changes. Your Confluence pages are up to date." | |
+| 3.3 | Edit single-page.md, repeat 3.1 | "Plan: 1 to change." then updates page | |
+| 3.4 | Revert edit, then: `ccfm $CFG apply --directory tests/smoke/docs --auto-approve` | Deploys all 7 files, no prompt | |
+| 3.5 | Repeat 3.4 | "No changes to apply." | |
+| 3.6 | `ccfm $CFG apply --directory tests/smoke/docs --force` | "Plan: 7 to add." (force treats all as new) | |
+| 3.7 | `ccfm $CFG apply --directory tests/smoke/docs --force --auto-approve` | Same as 3.6, no prompt | |
+
+### Interactive prompt rejection
+
+| # | Input | Expected | Pass/Fail |
+| --- | ------- | ---------- | ----------- |
+| 3.8 | Type `no` at prompt | "Apply cancelled." | |
+| 3.9 | Type `y` at prompt | "Apply cancelled." (only "yes" accepted) | |
+| 3.10 | Type `Yes` at prompt | Proceeds (case-insensitive) | |
+
+---
+
+## Phase 4: Dump
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 4.1 | `ccfm dump --file tests/smoke/docs/single-page/single-page.md` | Creates `.ccfm/dumps/<timestamp>/` dir with .adf.json | |
+| 4.2 | `ccfm dump --directory tests/smoke/docs --output-dir /tmp/adf-test` | Writes 7 .adf.json files to `/tmp/adf-test` | |
+| 4.3 | `ccfm dump --file tests/smoke/docs/example/CCFM\ Example/complete_example.md` | Succeeds (no NoneType crash on page links) | |
+
+> Clean up: `rm -rf .ccfm/dumps /tmp/adf-test`
+
+---
+
+## Phase 5: Destroy
+
+| # | Step | Expected | Pass/Fail |
+| --- | ------ | ---------- | ----------- |
+| 5.1 | Temporarily move `single-page.md` out of the docs dir | | |
+| 5.2 | `ccfm $CFG plan --directory tests/smoke/docs` | Shows "1 to destroy" for single-page | |
+| 5.3 | `ccfm $CFG apply --directory tests/smoke/docs --auto-approve` | Destroys single-page and its container | |
+| 5.4 | Repeat 5.3 | "No changes to apply." | |
+| 5.5 | Move `single-page.md` back | | |
+| 5.6 | `ccfm $CFG apply --directory tests/smoke/docs --auto-approve` | "Plan: 1 to add." — re-creates page | |
+
+---
+
+## Phase 6: State Commands
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 6.1 | `ccfm $CFG state list` | Shows all 14 tracked pages | |
+| 6.2 | `ccfm $CFG state show "tests/smoke/docs/single-page/single-page.md"` | Shows page_id, content_hash, title | |
+| 6.3 | `ccfm $CFG state pull > state-backup.json` | Valid JSON with "pages" and "version" keys | |
+| 6.4 | `ccfm $CFG state push state-backup.json` | "Remote state updated" | |
+| 6.5 | `ccfm $CFG state rm "tests/smoke/docs/single-page/single-page.md"` | "Removed '...' from state." | |
+| 6.6 | `ccfm $CFG state list` | Entry no longer present | |
+| 6.7 | `ccfm $CFG state push state-backup.json` | Restore original state | |
+
+---
+
+## Phase 7: Lock
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 7.1 | `ccfm $CFG lock status` | "State is not locked." | |
+| 7.2 | `ccfm $CFG lock acquire` | "Lock acquired by ..." | |
+| 7.3 | `ccfm $CFG lock status` | Shows lock owner, timestamp, operation | |
+| 7.4 | `ccfm $CFG apply --directory tests/smoke/docs --auto-approve --force` | Error: "State is locked by ..." | |
+| 7.5 | `ccfm $CFG lock release` | "Lock released." | |
+| 7.6 | `ccfm $CFG lock status` | "State is not locked." | |
+| 7.7 | `ccfm $CFG lock release` | Succeeds (idempotent) | |
+
+---
+
+## Phase 8: Error Handling
+
+| # | Command | Expected | Pass/Fail |
+| --- | --------- | ---------- | ----------- |
+| 8.1 | `ccfm $CFG apply --file nonexistent.md` | "Error: File not found: nonexistent.md" | |
+| 8.2 | `ccfm $CFG apply --directory nonexistent-dir` | "Error: Directory not found: nonexistent-dir" | |
+| 8.3 | `ccfm $CFG apply` | "Error: Specify either --file or --directory" | |
+
+---
+
+## Cleanup
+
+After testing, remove test pages from Confluence and reset state:
+
+```bash
+# Option A: Use the smoke test cleanup
+pytest tests/smoke/ --no-cov -v --cleanup-only
+
+# Option B: Manual reset
+ccfm $CFG state push /dev/stdin <<< '{"version": "1", "pages": {}}'
+# Then manually delete pages from Confluence UI
+```

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -460,7 +460,7 @@ def ccfm_run(smoke_creds):
     """Return a callable that invokes ccfm_convert with smoke credentials.
 
     Uses the subcommand CLI structure. The first positional arg should be
-    the subcommand (init, deploy, state, lock).
+    the subcommand (init, plan, apply, state, lock).
 
     Args:
         *extra_args: CLI arguments including subcommand.

--- a/tests/smoke/docs/state-management/page-alpha.md
+++ b/tests/smoke/docs/state-management/page-alpha.md
@@ -12,8 +12,8 @@ deploy_config:
 
 This page is used by the state management smoke tests to exercise:
 
-- `--changed-only` (this file is modified between runs to trigger an update)
-- `--plan` (shows as CREATE before first deploy, NO-OP after)
+- Change detection (this file is modified between runs to trigger an update)
+- `ccfm plan` (shows as add before first apply, no-op after)
 
 ## Original content
 

--- a/tests/smoke/manual_test.sh
+++ b/tests/smoke/manual_test.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# Interactive manual testing script for CCFM CLI.
+# Walks through all phases from MANUAL_TESTING.md step by step.
+#
+# Usage:
+#   source .env.smoke
+#   ./tests/smoke/manual_test.sh
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+CFG="--config tests/smoke/ccfm-smoke.yaml"
+SINGLE_PAGE="tests/smoke/docs/single-page/single-page.md"
+COMPLETE_EXAMPLE="tests/smoke/docs/example/CCFM Example/complete_example.md"
+SMOKE_DOCS="tests/smoke/docs"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Colours
+# ---------------------------------------------------------------------------
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m' # No colour
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+phase() {
+    echo ""
+    echo -e "${YELLOW}================================================================${NC}"
+    echo -e "${YELLOW}  $1${NC}"
+    echo -e "${YELLOW}================================================================${NC}"
+    echo ""
+}
+
+step_header() {
+    local num="$1"
+    local desc="$2"
+    local expected="$3"
+    echo -e "${CYAN}--- Step $num ---${NC}"
+    echo -e "${BOLD}$desc${NC}"
+    echo -e "${DIM}Expected: $expected${NC}"
+    echo ""
+}
+
+run_cmd() {
+    # Run a command, show it, then show output.
+    local cmd="$*"
+    echo -e "${DIM}\$ $cmd${NC}"
+    echo ""
+    eval "$cmd" 2>&1 || true
+    echo ""
+}
+
+run_cmd_interactive() {
+    # Run a command that needs direct TTY access (interactive prompts).
+    local cmd="$*"
+    echo -e "${DIM}\$ $cmd${NC}"
+    echo ""
+    eval "$cmd" || true
+    echo ""
+}
+
+verdict() {
+    # Ask user for pass/fail verdict.
+    echo -e -n "${BOLD}Result? [${GREEN}P${NC}${BOLD}ass / ${RED}F${NC}${BOLD}ail / ${YELLOW}S${NC}${BOLD}kip / ${RED}Q${NC}${BOLD}uit]: ${NC}"
+    read -r v
+    local lv
+    lv="$(echo "$v" | tr '[:upper:]' '[:lower:]')"
+    case "$lv" in
+        f|fail)
+            echo -e "${RED}FAIL${NC}"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            ;;
+        s|skip)
+            echo -e "${YELLOW}SKIP${NC}"
+            SKIP_COUNT=$((SKIP_COUNT + 1))
+            ;;
+        q|quit)
+            echo ""
+            summary
+            exit 0
+            ;;
+        *)
+            echo -e "${GREEN}PASS${NC}"
+            PASS_COUNT=$((PASS_COUNT + 1))
+            ;;
+    esac
+    echo ""
+}
+
+manual_note() {
+    echo -e "${YELLOW}>> $1${NC}"
+}
+
+summary() {
+    echo ""
+    echo -e "${BOLD}================================================================${NC}"
+    echo -e "${BOLD}  RESULTS${NC}"
+    echo -e "${BOLD}================================================================${NC}"
+    echo -e "  ${GREEN}Passed: $PASS_COUNT${NC}"
+    echo -e "  ${RED}Failed: $FAIL_COUNT${NC}"
+    echo -e "  ${YELLOW}Skipped: $SKIP_COUNT${NC}"
+    total=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+    echo -e "  Total:  $total"
+    echo ""
+    if [ "$FAIL_COUNT" -eq 0 ]; then
+        echo -e "  ${GREEN}All tests passed!${NC}"
+    else
+        echo -e "  ${RED}$FAIL_COUNT test(s) failed.${NC}"
+    fi
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if [ -z "${CONFLUENCE_DOMAIN:-}" ] || [ -z "${CONFLUENCE_TOKEN:-}" ]; then
+    echo -e "${RED}Error: Credentials not set. Run: source .env.smoke${NC}"
+    exit 1
+fi
+
+echo -e "${BOLD}CCFM Interactive Manual Test Runner${NC}"
+echo -e "${DIM}Project root: $PROJECT_ROOT${NC}"
+echo -e "${DIM}Config: tests/smoke/ccfm-smoke.yaml${NC}"
+echo ""
+echo "Press Enter to start, or Ctrl-C to abort."
+read -r
+
+# ===================================================================
+# Phase 1: CLI Help
+# ===================================================================
+
+phase "Phase 1: Verify CLI Help"
+
+step_header "1.1" "Root help" "Shows all subcommands (init, plan, apply, dump, state, lock)"
+run_cmd ccfm --help
+verdict
+
+step_header "1.2" "Init help" "Shows init options"
+run_cmd ccfm init --help
+verdict
+
+step_header "1.3" "Plan help" "Shows --file, --directory, --plan-exit-code, --force"
+run_cmd ccfm plan --help
+verdict
+
+step_header "1.4" "Apply help" "Shows --auto-approve, --force, --lock-id"
+run_cmd ccfm apply --help
+verdict
+
+step_header "1.5" "Dump help" "Shows --file, --directory, --output-dir"
+run_cmd ccfm dump --help
+verdict
+
+step_header "1.6" "State help" "Shows list, pull, push, rm, show"
+run_cmd ccfm state --help
+verdict
+
+step_header "1.7" "Lock help" "Shows status, acquire, release"
+run_cmd ccfm lock --help
+verdict
+
+# ===================================================================
+# Phase 2: Plan
+# ===================================================================
+
+phase "Phase 2: Plan"
+
+step_header "2.1" "Plan with no target" "Error: Specify either --file or --directory"
+run_cmd ccfm $CFG plan
+verdict
+
+step_header "2.2" "Plan single file" "Plan: 1 to add."
+run_cmd ccfm $CFG plan --file "$SINGLE_PAGE"
+verdict
+
+step_header "2.3" "Plan directory" "Plan: 7 to add."
+run_cmd ccfm $CFG plan --directory "$SMOKE_DOCS"
+verdict
+
+step_header "2.4" "Plan with --plan-exit-code" "Exit code 2"
+echo -e "${DIM}\$ ccfm $CFG plan --directory $SMOKE_DOCS --plan-exit-code${NC}"
+echo ""
+rc=0
+ccfm $CFG plan --directory "$SMOKE_DOCS" --plan-exit-code || rc=$?
+echo ""
+echo -e "${DIM}Exit code: $rc${NC}"
+verdict
+
+# ===================================================================
+# Phase 3: Apply
+# ===================================================================
+
+phase "Phase 3: Apply"
+
+step_header "3.1" "Apply single file (interactive)" "Prompts for 'yes', creates page on 'yes'"
+manual_note "Type 'yes' at the prompt"
+run_cmd_interactive ccfm $CFG apply --file "$SINGLE_PAGE"
+verdict
+
+step_header "3.2" "Re-apply unchanged file" "No changes. Your Confluence pages are up to date."
+run_cmd ccfm $CFG apply --auto-approve --file "$SINGLE_PAGE"
+verdict
+
+step_header "3.3" "Apply changed file (interactive)" "Plan: 1 to change."
+manual_note "Appending a line to single-page.md for change detection..."
+echo "" >> "$SINGLE_PAGE"
+echo "<!-- manual test change -->" >> "$SINGLE_PAGE"
+manual_note "Type 'yes' at the prompt"
+run_cmd_interactive ccfm $CFG apply --file "$SINGLE_PAGE"
+manual_note "Reverting change..."
+git checkout -- "$SINGLE_PAGE"
+verdict
+
+step_header "3.4" "Apply directory with --auto-approve" "Deploys all 7 files, no prompt"
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --auto-approve
+verdict
+
+step_header "3.5" "Re-apply directory (no changes)" "No changes to apply."
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --auto-approve
+verdict
+
+step_header "3.6" "Apply with --force (interactive)" "Plan: 7 to add. (force treats all as new)"
+manual_note "Type 'yes' at the prompt"
+run_cmd_interactive ccfm $CFG apply --directory "$SMOKE_DOCS" --force
+verdict
+
+step_header "3.7" "Apply with --force --auto-approve" "Same as 3.6, no prompt"
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --force --auto-approve
+verdict
+
+step_header "3.8" "Interactive rejection: 'no'" "Apply cancelled."
+manual_note "Type 'no' at the prompt"
+run_cmd_interactive ccfm $CFG apply --directory "$SMOKE_DOCS" --force
+verdict
+
+step_header "3.9" "Interactive rejection: 'y'" "Apply cancelled. (only 'yes' accepted)"
+manual_note "Type 'y' at the prompt"
+run_cmd_interactive ccfm $CFG apply --directory "$SMOKE_DOCS" --force
+verdict
+
+step_header "3.10" "Interactive accept: 'Yes'" "Proceeds (case-insensitive)"
+manual_note "Type 'Yes' at the prompt"
+run_cmd_interactive ccfm $CFG apply --directory "$SMOKE_DOCS" --force
+verdict
+
+# ===================================================================
+# Phase 4: Dump
+# ===================================================================
+
+phase "Phase 4: Dump"
+
+step_header "4.1" "Dump single file" "Creates .ccfm/dumps/<timestamp>/ dir with .adf.json"
+run_cmd ccfm dump --file "$SINGLE_PAGE"
+echo -e "${DIM}Dump directories:${NC}"
+ls .ccfm/dumps/ 2>/dev/null || echo "(none found)"
+verdict
+
+step_header "4.2" "Dump directory with --output-dir" "Writes .adf.json files to /tmp/ccfm-manual-test"
+rm -rf /tmp/ccfm-manual-test
+run_cmd ccfm dump --directory "$SMOKE_DOCS" --output-dir /tmp/ccfm-manual-test
+echo -e "${DIM}Output files:${NC}"
+find /tmp/ccfm-manual-test -name "*.adf.json" 2>/dev/null | head -20
+verdict
+
+step_header "4.3" "Dump file with page links (regression)" "Succeeds (no NoneType crash)"
+run_cmd ccfm dump --file "\"$COMPLETE_EXAMPLE\"" --output-dir /tmp/ccfm-manual-test-links
+verdict
+
+# Cleanup dump output
+rm -rf .ccfm/dumps /tmp/ccfm-manual-test /tmp/ccfm-manual-test-links
+
+# ===================================================================
+# Phase 5: Destroy
+# ===================================================================
+
+phase "Phase 5: Destroy"
+
+step_header "5.1-5.2" "Move file and plan destroy" "Shows destroy for single-page"
+mv "$SINGLE_PAGE" "$SINGLE_PAGE.bak"
+run_cmd ccfm $CFG plan --directory "$SMOKE_DOCS"
+verdict
+
+step_header "5.3" "Apply destroy" "Destroys single-page and its container"
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --auto-approve
+verdict
+
+step_header "5.4" "Re-apply after destroy (no changes)" "No changes to apply."
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --auto-approve
+verdict
+
+step_header "5.5-5.6" "Restore file and re-add" "Plan: 1 to add. Re-creates page"
+mv "$SINGLE_PAGE.bak" "$SINGLE_PAGE"
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --auto-approve
+verdict
+
+# ===================================================================
+# Phase 6: State Commands
+# ===================================================================
+
+phase "Phase 6: State Commands"
+
+step_header "6.1" "State list" "Shows tracked pages"
+run_cmd ccfm $CFG state list
+verdict
+
+step_header "6.2" "State show" "Shows page_id, content_hash, title"
+run_cmd ccfm $CFG state show "$SINGLE_PAGE"
+verdict
+
+step_header "6.3" "State pull" "Valid JSON with pages and version keys"
+run_cmd ccfm $CFG state pull
+# Save for later use
+ccfm $CFG state pull > /tmp/ccfm-state-backup.json 2>/dev/null
+verdict
+
+step_header "6.4" "State push (round-trip)" "Remote state updated"
+run_cmd ccfm $CFG state push /tmp/ccfm-state-backup.json
+verdict
+
+step_header "6.5" "State rm" "Removed from state"
+run_cmd ccfm $CFG state rm "$SINGLE_PAGE"
+verdict
+
+step_header "6.6" "State list (verify removal)" "Entry no longer present"
+run_cmd ccfm $CFG state list
+verdict
+
+step_header "6.7" "State push (restore)" "Restore original state"
+run_cmd ccfm $CFG state push /tmp/ccfm-state-backup.json
+rm -f /tmp/ccfm-state-backup.json
+verdict
+
+# ===================================================================
+# Phase 7: Lock
+# ===================================================================
+
+phase "Phase 7: Lock"
+
+step_header "7.1" "Lock status (unlocked)" "State is not locked."
+run_cmd ccfm $CFG lock status
+verdict
+
+step_header "7.2" "Lock acquire" "Lock acquired by ..."
+run_cmd ccfm $CFG lock acquire
+verdict
+
+step_header "7.3" "Lock status (locked)" "Shows lock owner, timestamp, operation"
+run_cmd ccfm $CFG lock status
+verdict
+
+step_header "7.4" "Apply blocked by lock" "Error: State is locked by ..."
+run_cmd ccfm $CFG apply --directory "$SMOKE_DOCS" --auto-approve --force
+verdict
+
+step_header "7.5" "Lock release" "Lock released."
+run_cmd ccfm $CFG lock release
+verdict
+
+step_header "7.6" "Lock status (unlocked again)" "State is not locked."
+run_cmd ccfm $CFG lock status
+verdict
+
+step_header "7.7" "Lock release (idempotent)" "Succeeds"
+run_cmd ccfm $CFG lock release
+verdict
+
+# ===================================================================
+# Phase 8: Error Handling
+# ===================================================================
+
+phase "Phase 8: Error Handling"
+
+step_header "8.1" "Apply missing file" "Error: File not found: nonexistent.md"
+run_cmd ccfm $CFG apply --file nonexistent.md
+verdict
+
+step_header "8.2" "Apply missing directory" "Error: Directory not found: nonexistent-dir"
+run_cmd ccfm $CFG apply --directory nonexistent-dir
+verdict
+
+step_header "8.3" "Apply no target" "Error: Specify either --file or --directory"
+run_cmd ccfm $CFG apply
+verdict
+
+# ===================================================================
+# Summary
+# ===================================================================
+
+summary

--- a/tests/smoke/test_cli_help.py
+++ b/tests/smoke/test_cli_help.py
@@ -1,0 +1,67 @@
+"""Smoke tests: CLI help outputs for all subcommands.
+
+These tests are lightweight — no credentials or Confluence access needed.
+They verify that --help exits 0 and produces sensible output for every subcommand.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from tests.smoke.conftest import PROJECT_ROOT
+
+pytestmark = pytest.mark.smoke
+
+
+def _run_help(*args):
+    """Run ccfm with --help and return the CompletedProcess."""
+    cmd = [sys.executable, "-m", "ccfm_convert", *args, "--help"]
+    return subprocess.run(
+        cmd,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestHelpOutputs:
+    """Validate --help for each subcommand exits 0."""
+
+    def test_root_help(self):
+        result = _run_help()
+        assert result.returncode == 0
+        assert "Deploy markdown to Confluence" in result.stdout
+
+    def test_init_help(self):
+        result = _run_help("init")
+        assert result.returncode == 0
+
+    def test_plan_help(self):
+        result = _run_help("plan")
+        assert result.returncode == 0
+        assert "--file" in result.stdout
+        assert "--directory" in result.stdout
+
+    def test_apply_help(self):
+        result = _run_help("apply")
+        assert result.returncode == 0
+        assert "--auto-approve" in result.stdout
+
+    def test_dump_help(self):
+        result = _run_help("dump")
+        assert result.returncode == 0
+        assert "--output-dir" in result.stdout
+
+    def test_state_help(self):
+        result = _run_help("state")
+        assert result.returncode == 0
+        assert "list" in result.stdout
+        assert "pull" in result.stdout
+
+    def test_lock_help(self):
+        result = _run_help("lock")
+        assert result.returncode == 0
+        assert "status" in result.stdout
+        assert "release" in result.stdout

--- a/tests/smoke/test_config_file.py
+++ b/tests/smoke/test_config_file.py
@@ -16,7 +16,7 @@ CONFIG_PAGE = SMOKE_DOCS / "config-test" / "config-page.md"
 class TestConfigFileDeploy:
     """Deploy using a ccfm.yaml config file instead of inline CLI flags."""
 
-    def test_deploy_via_config_file(self, confluence_live):
+    def test_apply_via_config_file(self, confluence_live):
         """--config ccfm.yaml with ${ENV_VAR} interpolation deploys successfully."""
         result = subprocess.run(
             [
@@ -25,7 +25,8 @@ class TestConfigFileDeploy:
                 "ccfm_convert",
                 "--config",
                 str(CONFIG_FILE),
-                "deploy",
+                "apply",
+                "--auto-approve",
                 "--file",
                 str(CONFIG_PAGE),
             ],
@@ -34,7 +35,7 @@ class TestConfigFileDeploy:
             text=True,
         )
 
-        assert result.returncode == 0, f"Config-file deploy failed:\n{result.stderr}"
+        assert result.returncode == 0, f"Config-file apply failed:\n{result.stderr}"
         assert (
             "Success" in result.stdout or "Updating" in result.stdout or "Creating" in result.stdout
         ), f"Unexpected output:\n{result.stdout}"

--- a/tests/smoke/test_directory_deploy.py
+++ b/tests/smoke/test_directory_deploy.py
@@ -13,21 +13,21 @@ class TestDirectoryDeploy:
     """Deploy an entire directory tree and verify all pages deploy successfully."""
 
     def test_tree_creates_all_pages(self, ccfm_run, confluence_live):
-        """deploy --directory deploys all markdown files."""
-        result = ccfm_run("deploy", "--directory", str(EXAMPLE_DIR))
+        """apply --directory deploys all markdown files."""
+        result = ccfm_run("apply", "--auto-approve", "--directory", str(EXAMPLE_DIR))
 
-        assert result.returncode == 0, f"Directory deploy failed:\n{result.stderr}"
+        assert result.returncode == 0, f"Directory apply failed:\n{result.stderr}"
         # Should mention creating or updating pages
         assert "Creating" in result.stdout or "Updating" in result.stdout
 
-    def test_plan_shows_no_ops_after_deploy(self, ccfm_run, confluence_live):
-        """deploy --plan after a full deploy reports NO-OP for all pages and exits 0."""
-        result = ccfm_run("deploy", "--plan", "--directory", str(EXAMPLE_DIR), check=False)
+    def test_plan_shows_no_changes_after_apply(self, ccfm_run, confluence_live):
+        """plan after a full apply reports no changes and exits 0."""
+        result = ccfm_run("plan", "--directory", str(EXAMPLE_DIR), check=False)
 
         assert result.returncode == 0, (
-            f"--plan after deploy should exit 0 (all NO-OP), got {result.returncode}.\n"
+            f"plan after apply should exit 0 (no changes), got {result.returncode}.\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
         assert (
-            "NO-OP" in result.stdout
-        ), f"Expected 'NO-OP' in --plan output after deploy.\nstdout: {result.stdout}"
+            "No changes" in result.stdout or "unchanged" in result.stdout
+        ), f"Expected no-changes message in plan output after apply.\nstdout: {result.stdout}"

--- a/tests/smoke/test_remote_state.py
+++ b/tests/smoke/test_remote_state.py
@@ -34,10 +34,10 @@ class TestInit:
 
 
 class TestLocking:
-    """Deploy acquires/releases lock automatically; lock commands work."""
+    """Apply acquires/releases lock automatically; lock commands work."""
 
     def test_lock_status_shows_unlocked(self, ccfm_run, confluence_live):
-        """ccfm lock status shows unlocked when no deploy is running."""
+        """ccfm lock status shows unlocked when no apply is running."""
         result = ccfm_run("lock", "status")
 
         assert result.returncode == 0, f"Lock status failed:\n{result.stderr}"
@@ -45,18 +45,18 @@ class TestLocking:
             "unlocked" in result.stdout.lower() or "not locked" in result.stdout.lower()
         ), f"Expected unlocked status.\nstdout: {result.stdout}"
 
-    def test_deploy_acquires_and_releases_lock(self, ccfm_run, confluence_live):
-        """After a deploy completes, the lock is released."""
-        # Deploy a page
-        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE))
-        assert result.returncode == 0, f"Deploy failed:\n{result.stderr}"
+    def test_apply_acquires_and_releases_lock(self, ccfm_run, confluence_live):
+        """After an apply completes, the lock is released."""
+        # Apply a page
+        result = ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
+        assert result.returncode == 0, f"Apply failed:\n{result.stderr}"
 
-        # Lock should be released after deploy
+        # Lock should be released after apply
         result = ccfm_run("lock", "status")
         assert result.returncode == 0
         assert (
             "unlocked" in result.stdout.lower() or "not locked" in result.stdout.lower()
-        ), f"Lock should be released after deploy.\nstdout: {result.stdout}"
+        ), f"Lock should be released after apply.\nstdout: {result.stdout}"
 
     def test_force_release_is_idempotent(self, ccfm_run, confluence_live):
         """lock release succeeds whether locked or unlocked (idempotent).
@@ -75,11 +75,11 @@ class TestLocking:
 
 
 class TestStateCommands:
-    """ccfm state list and ccfm state rm commands."""
+    """ccfm state list, show, pull, push, and rm commands."""
 
     def test_state_list_shows_deployed_pages(self, ccfm_run, confluence_live):
-        """ccfm state list shows pages after a deploy."""
-        ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+        """ccfm state list shows pages after an apply."""
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
 
         result = ccfm_run("state", "list")
 
@@ -88,9 +88,63 @@ class TestStateCommands:
             "single-page" in result.stdout
         ), f"Expected single-page in state list.\nstdout: {result.stdout}"
 
+    def test_state_pull_outputs_json(self, ccfm_run, confluence_live):
+        """ccfm state pull outputs valid JSON to stdout."""
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
+
+        result = ccfm_run("state", "pull")
+        assert result.returncode == 0, f"State pull failed:\n{result.stderr}"
+
+        import json
+
+        state = json.loads(result.stdout)
+        assert "pages" in state, "State JSON missing 'pages' key"
+        assert "version" in state, "State JSON missing 'version' key"
+
+    def test_state_show_displays_entry(self, ccfm_run, confluence_live):
+        """ccfm state show <path> outputs the entry for a specific page."""
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
+
+        # Find the .md state key
+        list_result = ccfm_run("state", "list")
+        state_key = None
+        for line in list_result.stdout.strip().split("\n"):
+            stripped = line.strip()
+            if stripped.endswith("single-page.md"):
+                state_key = stripped.split()[0] if stripped else None
+                break
+
+        assert state_key, f"Could not find single-page.md in state list:\n{list_result.stdout}"
+
+        result = ccfm_run("state", "show", state_key)
+        assert result.returncode == 0, f"State show failed:\n{result.stderr}"
+        assert "page_id" in result.stdout, "State show output missing page_id"
+
+    def test_state_push_round_trip(self, ccfm_run, confluence_live, tmp_path):
+        """state pull -> push round-trip preserves state."""
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
+
+        # Pull current state
+        pull_result = ccfm_run("state", "pull")
+        assert pull_result.returncode == 0
+
+        # Write to a temp file and push it back
+        state_file = tmp_path / "state.json"
+        state_file.write_text(pull_result.stdout)
+
+        push_result = ccfm_run("state", "push", str(state_file))
+        assert push_result.returncode == 0, f"State push failed:\n{push_result.stderr}"
+        assert (
+            "updated" in push_result.stdout.lower()
+        ), f"Expected 'updated' in push output:\n{push_result.stdout}"
+
+        # Verify state is still intact
+        verify_result = ccfm_run("state", "list")
+        assert "single-page" in verify_result.stdout
+
     def test_state_rm_removes_entry(self, ccfm_run, confluence_live):
         """ccfm state rm removes a page entry from remote state."""
-        ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
 
         # Find the state key by listing
         list_result = ccfm_run("state", "list")
@@ -112,3 +166,26 @@ class TestStateCommands:
             assert state_key not in list_after.stdout, (
                 f"State key {state_key} still present after rm.\n" f"stdout: {list_after.stdout}"
             )
+
+
+class TestLockAcquireAndBlock:
+    """Lock acquire blocks apply, lock release unblocks."""
+
+    def test_lock_acquire_blocks_apply(self, ccfm_run, confluence_live):
+        """Manually acquired lock blocks a subsequent apply."""
+        # Acquire lock manually
+        acquire_result = ccfm_run("lock", "acquire")
+        assert acquire_result.returncode == 0, f"Lock acquire failed:\n{acquire_result.stderr}"
+
+        try:
+            # Apply should fail because lock is held
+            apply_result = ccfm_run(
+                "apply", "--auto-approve", "--force", "--file", str(SINGLE_PAGE), check=False
+            )
+            assert apply_result.returncode != 0, "Apply should fail when lock is held"
+            assert (
+                "locked" in apply_result.stdout.lower() or "locked" in apply_result.stderr.lower()
+            )
+        finally:
+            # Always release lock to avoid blocking other tests
+            ccfm_run("lock", "release", check=False)

--- a/tests/smoke/test_single_file.py
+++ b/tests/smoke/test_single_file.py
@@ -1,4 +1,4 @@
-"""Smoke tests: single-file deployment via --file."""
+"""Smoke tests: single-file deployment and dump subcommand."""
 
 import pytest
 
@@ -7,38 +7,73 @@ from tests.smoke.conftest import SMOKE_DOCS
 pytestmark = pytest.mark.smoke
 
 SINGLE_PAGE = SMOKE_DOCS / "single-page" / "single-page.md"
+COMPLETE_EXAMPLE = SMOKE_DOCS / "example" / "CCFM Example" / "complete_example.md"
 
 
 class TestSingleFileDeploy:
     """Deploy a single markdown file and verify it deploys successfully."""
 
     def test_page_created(self, ccfm_run, confluence_live):
-        """deploy --file deploys successfully."""
-        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+        """apply --file deploys successfully."""
+        result = ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
 
-        assert result.returncode == 0, f"Deploy failed:\n{result.stderr}"
+        assert result.returncode == 0, f"Apply failed:\n{result.stderr}"
         assert (
             "Success" in result.stdout or "Updating" in result.stdout or "Creating" in result.stdout
         )
 
-    def test_page_updated_on_redeploy(self, ccfm_run, confluence_live):
-        """Re-deploying the same file updates (not duplicates) the page."""
-        # First deploy
-        ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+    def test_page_updated_on_force_reapply(self, ccfm_run, confluence_live):
+        """Re-applying with --force updates (not duplicates) the page."""
+        # First apply
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
 
-        # Second deploy should update
-        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE))
+        # Second apply with --force should re-deploy even though content is unchanged
+        result = ccfm_run("apply", "--auto-approve", "--force", "--file", str(SINGLE_PAGE))
         assert result.returncode == 0
-        assert "Updating" in result.stdout, "Expected 'Updating' in output for a re-deploy"
+        assert "Updating" in result.stdout, "Expected 'Updating' in output for a --force re-apply"
 
-    def test_dump_mode_writes_adf(self, ccfm_run):
-        """deploy --dump writes an .adf.json file locally without API calls."""
-        adf_file = SINGLE_PAGE.with_suffix(".adf.json")
-        adf_file.unlink(missing_ok=True)
+    def test_reapply_unchanged_is_noop(self, ccfm_run, confluence_live):
+        """Re-applying an unchanged file is a no-op (change detection)."""
+        # First apply
+        ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
 
-        result = ccfm_run("deploy", "--file", str(SINGLE_PAGE), "--dump")
+        # Second apply without --force should detect no changes
+        result = ccfm_run("apply", "--auto-approve", "--file", str(SINGLE_PAGE))
         assert result.returncode == 0
-        assert adf_file.exists(), ".adf.json file was not written by --dump"
+        assert "No changes" in result.stdout, "Expected no-op on unchanged re-apply"
 
-        # Cleanup the generated file
-        adf_file.unlink(missing_ok=True)
+    def test_dump_writes_adf(self, ccfm_run, tmp_path):
+        """dump --file writes an .adf.json file to the output directory."""
+        output_dir = tmp_path / "dump-output"
+
+        result = ccfm_run("dump", "--file", str(SINGLE_PAGE), "--output-dir", str(output_dir))
+        assert result.returncode == 0
+        assert "Dump complete" in result.stdout
+
+        # Verify at least one .adf.json file was created
+        adf_files = list(output_dir.rglob("*.adf.json"))
+        assert len(adf_files) > 0, "No .adf.json files found in dump output directory"
+
+    def test_dump_directory(self, ccfm_run, tmp_path):
+        """dump --directory writes .adf.json for all files without API calls."""
+        output_dir = tmp_path / "dump-dir-output"
+
+        result = ccfm_run("dump", "--directory", str(SMOKE_DOCS), "--output-dir", str(output_dir))
+        assert result.returncode == 0
+        assert "Dump complete" in result.stdout
+
+        adf_files = list(output_dir.rglob("*.adf.json"))
+        assert len(adf_files) >= 5, f"Expected at least 5 .adf.json files, got {len(adf_files)}"
+
+    def test_dump_with_page_links_no_crash(self, ccfm_run, tmp_path):
+        """dump mode doesn't crash on files with confluence_page:// links.
+
+        Regression test: the old --dump flag crashed with NoneType error on
+        complete_example.md because resolve_page_links() was called with api=None.
+        The new dump subcommand skips page link resolution entirely.
+        """
+        output_dir = tmp_path / "dump-links-output"
+
+        result = ccfm_run("dump", "--file", str(COMPLETE_EXAMPLE), "--output-dir", str(output_dir))
+        assert result.returncode == 0, f"Dump crashed on page links file:\n{result.stderr}"
+        assert "Dump complete" in result.stdout

--- a/tests/smoke/test_state_management.py
+++ b/tests/smoke/test_state_management.py
@@ -1,4 +1,4 @@
-"""Smoke tests: state management — plan mode, --changed-only, --archive-orphans."""
+"""Smoke tests: state management — plan, apply, and destroy behaviour."""
 
 import pytest
 
@@ -16,162 +16,45 @@ BETA_KEY = "page-beta.md"
 
 
 class TestPlanMode:
-    """--plan exit codes and output before/after a deploy."""
+    """ccfm plan output before/after an apply."""
 
-    def test_plan_before_deploy_shows_creates(self, ccfm_run, confluence_live):
-        """deploy --plan --plan-exit-code before any deploy exits 2 and lists CREATE actions."""
-        result = ccfm_run(
-            "deploy", "--plan", "--plan-exit-code", "--directory", str(STATE_DIR), check=False
-        )
+    def test_plan_before_apply_shows_adds(self, ccfm_run, confluence_live):
+        """plan --plan-exit-code before any apply exits 2 and lists add actions."""
+        result = ccfm_run("plan", "--plan-exit-code", "--directory", str(STATE_DIR), check=False)
 
         assert result.returncode == 2, (
-            f"Expected exit 2 (pending changes) before first deploy, "
+            f"Expected exit 2 (pending changes) before first apply, "
             f"got {result.returncode}.\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
         assert (
-            "CREATE" in result.stdout
-        ), f"Expected 'CREATE' in --plan output before deploy.\nstdout: {result.stdout}"
+            "add" in result.stdout
+        ), f"Expected 'add' in plan output before apply.\nstdout: {result.stdout}"
 
-    def test_plan_after_deploy_shows_no_ops(self, ccfm_run, confluence_live):
-        """deploy --plan after a full deploy exits 0 and shows NO-OP for all pages."""
-        # Deploy both pages first
-        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
-        assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
+    def test_plan_after_apply_shows_no_changes(self, ccfm_run, confluence_live):
+        """plan after a full apply exits 0 and shows no changes."""
+        # Apply both pages first
+        result = ccfm_run("apply", "--auto-approve", "--directory", str(STATE_DIR))
+        assert result.returncode == 0, f"Initial apply failed:\n{result.stderr}"
 
-        result = ccfm_run("deploy", "--plan", "--directory", str(STATE_DIR), check=False)
+        result = ccfm_run("plan", "--directory", str(STATE_DIR), check=False)
 
         assert result.returncode == 0, (
-            f"Expected exit 0 (all NO-OP) after deploy, got {result.returncode}.\n"
+            f"Expected exit 0 (no changes) after apply, got {result.returncode}.\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
         assert (
-            "NO-OP" in result.stdout
-        ), f"Expected 'NO-OP' in --plan output.\nstdout: {result.stdout}"
+            "No changes" in result.stdout or "unchanged" in result.stdout
+        ), f"Expected no-changes message in plan output.\nstdout: {result.stdout}"
 
 
-class TestChangedOnly:
-    """--changed-only skips unchanged files and deploys modified ones."""
+class TestDestroyBehavior:
+    """Destroy detection removes pages whose source files are deleted."""
 
-    def test_changed_only_skips_unchanged(self, ccfm_run, confluence_live):
-        """After a clean deploy, --changed-only reports 0 files with changes."""
-        # Ensure both pages are deployed
-        ccfm_run("deploy", "--directory", str(STATE_DIR))
-
-        result = ccfm_run("deploy", "--changed-only", "--directory", str(STATE_DIR))
-
-        assert result.returncode == 0, f"--changed-only failed:\n{result.stderr}"
-        assert (
-            "0 file(s) with changes" in result.stdout
-        ), f"Expected '0 file(s) with changes' in output.\nstdout: {result.stdout}"
-
-    def test_changed_only_deploys_modified_file(self, ccfm_run, tmp_path, confluence_live):
-        """After modifying page-alpha, --changed-only deploys only that file."""
-        # Ensure a clean baseline deploy first
-        ccfm_run("deploy", "--directory", str(STATE_DIR))
-
-        # Write a modified copy of page-alpha with new content
-        original_content = PAGE_ALPHA.read_text(encoding="utf-8")
-        modified_content = original_content.replace(
-            "Version: **1**",
-            "Version: **2** — updated by smoke test",
-        )
-
-        try:
-            PAGE_ALPHA.write_text(modified_content, encoding="utf-8")
-
-            result = ccfm_run("deploy", "--changed-only", "--directory", str(STATE_DIR))
-
-            assert (
-                result.returncode == 0
-            ), f"--changed-only after modification failed:\n{result.stderr}"
-            # The modified page should have been processed
-            assert ALPHA_KEY.replace(".md", "") in result.stdout or "Updating" in result.stdout, (
-                f"Expected page-alpha to appear in --changed-only output.\n"
-                f"stdout: {result.stdout}"
-            )
-            # Unchanged page-beta must NOT be deployed (issue #6)
-            assert "page-beta" not in result.stdout, (
-                f"Unchanged page-beta should NOT be deployed with --changed-only.\n"
-                f"stdout: {result.stdout}"
-            )
-        finally:
-            # Always restore the original content
-            PAGE_ALPHA.write_text(original_content, encoding="utf-8")
-
-
-class TestChangedOnlyWithArchiveOrphans:
-    """Regression tests for issue #3.
-
-    When --changed-only detects 0 changes, the deploy must be a no-op — no pages
-    should be updated and no pages should be archived.  Previously the tool would
-    traverse the full tree despite 0 changes, then archive every page because the
-    orphan check compared state against an empty visited set.
-    """
-
-    def test_noop_run_does_not_archive_any_pages(self, ccfm_run, confluence_live):
-        """Second deploy with --changed-only --archive-orphans must not archive anything."""
-        # Step 1: clean deploy
-        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
-        assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
-
-        # Step 2: re-run with both flags — no files have changed, must be a no-op
-        result = ccfm_run(
-            "deploy",
-            "--changed-only",
-            "--archive-orphans",
-            "--directory",
-            str(STATE_DIR),
-            check=False,
-        )
-
-        assert result.returncode == 0, f"--changed-only --archive-orphans failed:\n{result.stderr}"
-        assert (
-            "No changes to deploy" in result.stdout
-        ), f"Expected early-exit message when 0 changes detected.\nstdout: {result.stdout}"
-
-    def test_unchanged_files_not_treated_as_orphans(self, ccfm_run, confluence_live):
-        """When only one file changes, unchanged files on disk must not be archived."""
-        # Step 1: clean baseline deploy
-        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
-        assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
-
-        # Step 2: modify page-alpha only
-        original_content = PAGE_ALPHA.read_text(encoding="utf-8")
-        modified_content = original_content.replace(
-            "Version: **1**",
-            "Version: **3** — orphan regression test",
-        )
-        try:
-            PAGE_ALPHA.write_text(modified_content, encoding="utf-8")
-
-            result = ccfm_run(
-                "deploy",
-                "--changed-only",
-                "--archive-orphans",
-                "--directory",
-                str(STATE_DIR),
-                check=False,
-            )
-
-            assert (
-                result.returncode == 0
-            ), f"--changed-only --archive-orphans failed:\n{result.stderr}"
-
-        finally:
-            PAGE_ALPHA.write_text(original_content, encoding="utf-8")
-
-
-class TestArchiveOrphans:
-    """--archive-orphans removes pages no longer tracked in the directory."""
-
-    def test_archive_orphans_removes_absent_page(self, ccfm_run, confluence_live):
-        """Deploy alpha+beta, then run with --archive-orphans on alpha-only dir.
-
-        The beta page should be archived and removed from state.
-        """
+    def test_plan_shows_destroy_for_removed_file(self, ccfm_run, confluence_live):
+        """After removing a file, plan shows a destroy action."""
         # Step 1: Deploy both pages to ensure beta is tracked
-        result = ccfm_run("deploy", "--directory", str(STATE_DIR))
-        assert result.returncode == 0, f"Initial deploy failed:\n{result.stderr}"
+        result = ccfm_run("apply", "--auto-approve", "--directory", str(STATE_DIR))
+        assert result.returncode == 0, f"Initial apply failed:\n{result.stderr}"
 
         # Step 2: Temporarily move page-beta out of the directory so it becomes an orphan
         beta_backup = PAGE_BETA.with_suffix(".md.bak")
@@ -179,16 +62,45 @@ class TestArchiveOrphans:
 
         try:
             result = ccfm_run(
-                "deploy",
-                "--archive-orphans",
+                "plan",
+                "--directory",
+                str(STATE_DIR),
+                "--docs-root",
+                str(STATE_DIR),
+                check=False,
+            )
+
+            assert result.returncode == 0, f"plan failed:\n{result.stderr}"
+            assert (
+                "destroy" in result.stdout
+            ), f"Expected 'destroy' in plan output.\nstdout: {result.stdout}"
+
+        finally:
+            # Restore page-beta so subsequent tests/cleanup can find it
+            beta_backup.rename(PAGE_BETA)
+
+    def test_apply_destroys_removed_page(self, ccfm_run, confluence_live):
+        """Apply with --auto-approve destroys the page and removes from state."""
+        # Step 1: Deploy both pages
+        result = ccfm_run("apply", "--auto-approve", "--directory", str(STATE_DIR))
+        assert result.returncode == 0, f"Initial apply failed:\n{result.stderr}"
+
+        # Step 2: Move page-beta out
+        beta_backup = PAGE_BETA.with_suffix(".md.bak")
+        PAGE_BETA.rename(beta_backup)
+
+        try:
+            result = ccfm_run(
+                "apply",
+                "--auto-approve",
                 "--directory",
                 str(STATE_DIR),
                 "--docs-root",
                 str(STATE_DIR),
             )
 
-            assert result.returncode == 0, f"--archive-orphans failed:\n{result.stderr}"
+            assert result.returncode == 0, f"apply with destroy failed:\n{result.stderr}"
 
         finally:
-            # Restore page-beta so subsequent tests/cleanup can find it
+            # Restore page-beta
             beta_backup.rename(PAGE_BETA)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,8 +29,8 @@ def mock_api():
     return api
 
 
-def _base_deploy_argv(tmp_file_or_dir, *, is_dir=False, extra=None):
-    """Build a standard deploy sys.argv list."""
+def _base_plan_argv(tmp_file_or_dir, *, is_dir=False, extra=None):
+    """Build a standard plan sys.argv list."""
     argv = [
         "main.py",
         "--domain",
@@ -41,7 +41,31 @@ def _base_deploy_argv(tmp_file_or_dir, *, is_dir=False, extra=None):
         "token",
         "--space",
         "TEST",
-        "deploy",
+        "plan",
+    ]
+    if is_dir:
+        argv += ["--directory", str(tmp_file_or_dir)]
+    else:
+        argv += ["--file", str(tmp_file_or_dir)]
+    if extra:
+        argv.extend(extra)
+    return argv
+
+
+def _base_apply_argv(tmp_file_or_dir, *, is_dir=False, extra=None):
+    """Build a standard apply sys.argv list with --auto-approve by default."""
+    argv = [
+        "main.py",
+        "--domain",
+        "example.atlassian.net",
+        "--email",
+        "test@example.com",
+        "--token",
+        "token",
+        "--space",
+        "TEST",
+        "apply",
+        "--auto-approve",
     ]
     if is_dir:
         argv += ["--directory", str(tmp_file_or_dir)]
@@ -103,6 +127,36 @@ def _base_lock_argv(subcommand):
         "lock",
         subcommand,
     ]
+
+
+def _mock_plan_with_changes(files=None):
+    """Create a mock plan that reports has_changes=True with actionable page_actions."""
+    plan = Mock()
+    plan.has_changes.return_value = True
+    plan.destroy_actions = []
+    if files:
+        actions = []
+        for f in files:
+            action = Mock()
+            action.action = "add"
+            action.filepath = f
+            actions.append(action)
+        plan.page_actions = actions
+    else:
+        action = Mock()
+        action.action = "add"
+        action.filepath = Path("/tmp/fake.md")
+        plan.page_actions = [action]
+    return plan
+
+
+def _mock_plan_no_changes():
+    """Create a mock plan that reports has_changes=False."""
+    plan = Mock()
+    plan.has_changes.return_value = False
+    plan.destroy_actions = []
+    plan.page_actions = []
+    return plan
 
 
 # ---------------------------------------------------------------------------
@@ -169,14 +223,25 @@ class TestCLIArguments:
                 main.main()
         assert exc_info.value.code == 1
 
-    def test_missing_credentials_exits_with_error(self, tmp_path):
-        """Missing required credentials cause SystemExit."""
+    def test_missing_credentials_exits_with_error_plan(self, tmp_path):
+        """Missing required credentials cause SystemExit for plan."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
         with pytest.raises(SystemExit):
             with patch(
                 "sys.argv",
-                ["main.py", "deploy", "--file", str(test_file)],
+                ["main.py", "plan", "--file", str(test_file)],
+            ):
+                main.main()
+
+    def test_missing_credentials_exits_with_error_apply(self, tmp_path):
+        """Missing required credentials cause SystemExit for apply."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                ["main.py", "apply", "--file", str(test_file), "--auto-approve"],
             ):
                 main.main()
 
@@ -219,140 +284,29 @@ class TestInitSubcommand:
         output = mock_stdout.getvalue()
         assert "Looking up space: TEST" in output
 
+    @patch("ccfm_convert.main.init_remote_state")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_init_prints_destroy_warning(self, mock_api_class, mock_init, capsys):
+        """init prints the destroy warning message."""
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
 
-# ---------------------------------------------------------------------------
-# Deploy subcommand — dump mode
-# ---------------------------------------------------------------------------
-
-
-class TestDeployDumpMode:
-    """Test deploy --dump (no API, no state, no lock)."""
-
-    @patch("ccfm_convert.main.deploy_page")
-    def test_dump_file_calls_deploy_page_with_dump_true(self, mock_deploy, tmp_path):
-        """--dump with --file calls deploy_page(dump=True) without credentials."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "deploy",
-                "--file",
-                str(test_file),
-                "--dump",
-            ],
-        ):
+        with patch("sys.argv", _base_init_argv()):
             main.main()
 
-        mock_deploy.assert_called_once()
-        assert mock_deploy.call_args[1]["dump"] is True
-
-    @patch("ccfm_convert.main.deploy_tree")
-    def test_dump_directory_calls_deploy_tree_with_dump_true(self, mock_deploy_tree, tmp_path):
-        """--dump with --directory calls deploy_tree(dump=True)."""
-        test_dir = tmp_path / "docs"
-        test_dir.mkdir()
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "deploy",
-                "--directory",
-                str(test_dir),
-                "--dump",
-            ],
-        ):
-            main.main()
-
-        mock_deploy_tree.assert_called_once()
-        assert mock_deploy_tree.call_args[1]["dump"] is True
-
-    @patch("ccfm_convert.main.deploy_page")
-    @patch("sys.stdout", new_callable=StringIO)
-    def test_dump_mode_output(self, mock_stdout, mock_deploy, tmp_path):
-        """Dump mode prints 'Dump mode' and does NOT print 'Deployment complete'."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "deploy",
-                "--file",
-                str(test_file),
-                "--dump",
-            ],
-        ):
-            main.main()
-
-        output = mock_stdout.getvalue()
-        assert "Dump mode" in output
-        assert "Deployment complete" not in output
-
-    @patch("ccfm_convert.main.deploy_page")
-    def test_dump_mode_with_git_repo_url(self, mock_deploy, tmp_path):
-        """--dump passes git_repo_url to deploy_page."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        with patch(
-            "sys.argv",
-            [
-                "main.py",
-                "deploy",
-                "--file",
-                str(test_file),
-                "--dump",
-                "--git-repo-url",
-                "https://github.com/user/repo",
-            ],
-        ):
-            main.main()
-
-        call_args = mock_deploy.call_args[0]
-        assert call_args[4] == "https://github.com/user/repo"
+        captured = capsys.readouterr()
+        assert "destroy operations" in captured.out
+        assert "Removing files or folders" in captured.out
 
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — no file or directory
+# Plan subcommand
 # ---------------------------------------------------------------------------
 
 
-class TestDeployNoTarget:
-    """Test deploy without --file or --directory."""
-
-    def test_no_file_or_directory_exits_with_error(self):
-        """Deploy without --file or --directory exits 1."""
-        with pytest.raises(SystemExit):
-            with patch(
-                "sys.argv",
-                [
-                    "main.py",
-                    "--domain",
-                    "example.atlassian.net",
-                    "--email",
-                    "test@example.com",
-                    "--token",
-                    "token",
-                    "--space",
-                    "TEST",
-                    "deploy",
-                ],
-            ):
-                main.main()
-
-
-# ---------------------------------------------------------------------------
-# Deploy subcommand — plan mode
-# ---------------------------------------------------------------------------
-
-
-class TestDeployPlanMode:
-    """Test deploy --plan (needs credentials + mgmt page + state, no lock)."""
+class TestPlanSubcommand:
+    """Test the 'plan' subcommand."""
 
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
@@ -368,7 +322,7 @@ class TestDeployPlanMode:
         mock_state_class,
         tmp_path,
     ):
-        """--plan exits 0 when there are no pending changes."""
+        """plan with no changes returns normally (no sys.exit call)."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -376,15 +330,13 @@ class TestDeployPlanMode:
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
 
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = False
+        mock_plan = _mock_plan_no_changes()
         mock_compute_plan.return_value = mock_plan
 
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("sys.argv", _base_deploy_argv(test_file, extra=["--plan"])):
-                main.main()
+        # Should NOT raise SystemExit — just returns normally
+        with patch("sys.argv", _base_plan_argv(test_file)):
+            main.main()
 
-        assert exc_info.value.code == 0
         mock_compute_plan.assert_called_once()
         mock_plan.print_summary.assert_called_once()
 
@@ -393,7 +345,7 @@ class TestDeployPlanMode:
     @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_plan_has_changes_exits_zero_by_default(
+    def test_plan_has_changes_returns_normally(
         self,
         mock_api_class,
         mock_find_mgmt,
@@ -402,7 +354,7 @@ class TestDeployPlanMode:
         mock_state_class,
         tmp_path,
     ):
-        """--plan exits 0 even when there are pending changes (CI-friendly default)."""
+        """plan with changes returns normally (no sys.exit)."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -410,15 +362,14 @@ class TestDeployPlanMode:
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
 
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = True
+        mock_plan = _mock_plan_with_changes()
         mock_compute_plan.return_value = mock_plan
 
-        with pytest.raises(SystemExit) as exc_info:
-            with patch("sys.argv", _base_deploy_argv(test_file, extra=["--plan"])):
-                main.main()
+        # Should NOT raise SystemExit
+        with patch("sys.argv", _base_plan_argv(test_file)):
+            main.main()
 
-        assert exc_info.value.code == 0
+        mock_compute_plan.assert_called_once()
 
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
@@ -434,7 +385,7 @@ class TestDeployPlanMode:
         mock_state_class,
         tmp_path,
     ):
-        """--plan --plan-exit-code exits 2 when there are pending changes."""
+        """--plan-exit-code exits 2 when there are pending changes."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -442,17 +393,13 @@ class TestDeployPlanMode:
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
 
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = True
+        mock_plan = _mock_plan_with_changes()
         mock_compute_plan.return_value = mock_plan
 
         with pytest.raises(SystemExit) as exc_info:
             with patch(
                 "sys.argv",
-                _base_deploy_argv(
-                    test_file,
-                    extra=["--plan", "--plan-exit-code"],
-                ),
+                _base_plan_argv(test_file, extra=["--plan-exit-code"]),
             ):
                 main.main()
 
@@ -472,7 +419,7 @@ class TestDeployPlanMode:
         mock_state_class,
         tmp_path,
     ):
-        """--plan --plan-exit-code exits 0 when there are no changes."""
+        """--plan-exit-code exits 0 when there are no changes."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -480,57 +427,17 @@ class TestDeployPlanMode:
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
 
-        mock_plan = Mock()
-        mock_plan.has_changes.return_value = False
+        mock_plan = _mock_plan_no_changes()
         mock_compute_plan.return_value = mock_plan
 
         with pytest.raises(SystemExit) as exc_info:
             with patch(
                 "sys.argv",
-                _base_deploy_argv(
-                    test_file,
-                    extra=["--plan", "--plan-exit-code"],
-                ),
+                _base_plan_argv(test_file, extra=["--plan-exit-code"]),
             ):
                 main.main()
 
         assert exc_info.value.code == 0
-
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.compute_plan")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_plan_with_archive_orphans(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_compute_plan,
-        mock_backend_class,
-        mock_state_class,
-        tmp_path,
-    ):
-        """--plan --archive-orphans passes archive_orphans=True to compute_plan."""
-        test_file = tmp_path / "test.md"
-        test_file.write_text("# Test")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_compute_plan.return_value = Mock()
-
-        with pytest.raises(SystemExit):
-            with patch(
-                "sys.argv",
-                _base_deploy_argv(
-                    test_file,
-                    extra=["--plan", "--archive-orphans"],
-                ),
-            ):
-                main.main()
-
-        call_kwargs = mock_compute_plan.call_args[1]
-        assert call_kwargs["archive_orphans"] is True
 
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
@@ -546,7 +453,7 @@ class TestDeployPlanMode:
         mock_state_class,
         tmp_path,
     ):
-        """--plan with --directory excludes .page_content.md files."""
+        """plan with --directory excludes .page_content.md files."""
         docs = tmp_path / "docs"
         docs.mkdir()
         (docs / "a.md").write_text("# A")
@@ -555,36 +462,240 @@ class TestDeployPlanMode:
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
-        mock_compute_plan.return_value = Mock()
+        mock_compute_plan.return_value = _mock_plan_no_changes()
 
-        with pytest.raises(SystemExit):
-            with patch("sys.argv", _base_deploy_argv(docs, is_dir=True, extra=["--plan"])):
-                main.main()
+        with patch("sys.argv", _base_plan_argv(docs, is_dir=True)):
+            main.main()
 
         call_kwargs = mock_compute_plan.call_args[1]
         files = call_kwargs["files"]
         assert all(f.name != ".page_content.md" for f in files)
 
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_no_lock_acquired(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """plan does NOT instantiate LockManager."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_compute_plan.return_value = _mock_plan_no_changes()
+
+        with patch("sys.argv", _base_plan_argv(test_file)):
+            main.main()
+
+        mock_lock_class.assert_not_called()
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_plan_force_flag_passed_to_compute_plan(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+    ):
+        """--force is passed to compute_plan."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_compute_plan.return_value = _mock_plan_no_changes()
+
+        with patch("sys.argv", _base_plan_argv(test_file, extra=["--force"])):
+            main.main()
+
+        call_kwargs = mock_compute_plan.call_args[1]
+        assert call_kwargs["force"] is True
+
+    def test_plan_no_file_or_directory_exits(self):
+        """plan without --file or --directory exits 1."""
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "token",
+                    "--space",
+                    "TEST",
+                    "plan",
+                ],
+            ):
+                main.main()
+
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — live single-file deployment
+# Apply subcommand — dump mode
 # ---------------------------------------------------------------------------
 
 
-class TestDeploySingleFile:
-    """Test single-file live deployment (with lock)."""
+class TestDumpSubcommand:
+    """Test ccfm dump subcommand (no API, no state, no lock)."""
+
+    @patch("ccfm_convert.main.dump_page")
+    def test_dump_file_calls_dump_page(self, mock_dump, tmp_path):
+        """dump --file calls dump_page with output directory."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        with patch("sys.argv", ["main.py", "dump", "--file", str(test_file)]):
+            main.main()
+
+        mock_dump.assert_called_once()
+        args = mock_dump.call_args[0]
+        assert args[0] == test_file
+        assert ".ccfm/dumps/" in str(args[1])
+
+    @patch("ccfm_convert.main.dump_tree")
+    def test_dump_directory_calls_dump_tree(self, mock_dump_tree, tmp_path):
+        """dump --directory calls dump_tree with output directory."""
+        test_dir = tmp_path / "docs"
+        test_dir.mkdir()
+
+        with patch("sys.argv", ["main.py", "dump", "--directory", str(test_dir)]):
+            main.main()
+
+        mock_dump_tree.assert_called_once()
+        args = mock_dump_tree.call_args[0]
+        assert args[0] == test_dir
+        assert ".ccfm/dumps/" in str(args[2])
+
+    @patch("ccfm_convert.main.dump_page")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_dump_output_message(self, mock_stdout, mock_dump, tmp_path):
+        """Dump prints summary with output directory path."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        with patch("sys.argv", ["main.py", "dump", "--file", str(test_file)]):
+            main.main()
+
+        output = mock_stdout.getvalue()
+        assert "Dump complete!" in output
+        assert ".ccfm/dumps/" in output
+
+    @patch("ccfm_convert.main.dump_page")
+    def test_dump_with_output_dir(self, mock_dump, tmp_path):
+        """dump --output-dir uses the specified directory."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+        out_dir = tmp_path / "my-output"
+
+        with patch(
+            "sys.argv",
+            ["main.py", "dump", "--file", str(test_file), "--output-dir", str(out_dir)],
+        ):
+            main.main()
+
+        assert mock_dump.call_args[0][1] == out_dir
+        assert out_dir.exists()
+
+    @patch("ccfm_convert.main.dump_page")
+    def test_dump_with_git_repo_url(self, mock_dump, tmp_path):
+        """dump passes git_repo_url to dump_page."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "dump",
+                "--file",
+                str(test_file),
+                "--git-repo-url",
+                "https://github.com/user/repo",
+            ],
+        ):
+            main.main()
+
+        assert mock_dump.call_args[0][2] == "https://github.com/user/repo"
+
+    def test_dump_no_target_error(self, capsys):
+        """dump without --file or --directory exits with error."""
+        with patch("sys.argv", ["main.py", "dump"]):
+            with pytest.raises(SystemExit, match="1"):
+                main.main()
+
+    def test_dump_missing_file_error(self, tmp_path):
+        """dump --file with non-existent file exits with error."""
+        missing = tmp_path / "nope.md"
+        with patch("sys.argv", ["main.py", "dump", "--file", str(missing)]):
+            with pytest.raises(SystemExit):
+                main.main()
+
+    def test_dump_missing_directory_error(self, tmp_path):
+        """dump --directory with non-existent directory exits with error."""
+        missing = tmp_path / "nope"
+        with patch("sys.argv", ["main.py", "dump", "--directory", str(missing)]):
+            with pytest.raises(SystemExit):
+                main.main()
+
+    def test_dump_output_dir_creation_failure(self, tmp_path):
+        """dump exits gracefully when output directory cannot be created."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+        # Use a path that cannot be created (file exists where dir would be)
+        blocker = tmp_path / "blocker"
+        blocker.write_text("I am a file")
+        bad_dir = blocker / "subdir"
+
+        with patch(
+            "sys.argv",
+            ["main.py", "dump", "--file", str(test_file), "--output-dir", str(bad_dir)],
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                main.main()
+
+
+# ---------------------------------------------------------------------------
+# Apply subcommand — single-file deployment
+# ---------------------------------------------------------------------------
+
+
+class TestApplySingleFile:
+    """Test single-file live deployment via apply (with lock)."""
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
     @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_single_file_deployment(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy,
         mock_hierarchy,
         mock_backend_class,
@@ -592,7 +703,7 @@ class TestDeploySingleFile:
         mock_lock_class,
         tmp_path,
     ):
-        """Deploy a single file: acquires lock, deploys, saves state, releases lock."""
+        """Apply a single file: acquires lock, deploys, saves state, releases lock."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -602,12 +713,14 @@ class TestDeploySingleFile:
         mock_hierarchy.return_value = ("parent123", [])
         mock_deploy.return_value = "deployed-page-id"
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_file)):
+        with patch("sys.argv", _base_apply_argv(test_file)):
             main.main()
 
         mock_lock.acquire.assert_called_once()
@@ -621,12 +734,14 @@ class TestDeploySingleFile:
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
     @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_hierarchy_pages_tracked_in_state_for_single_file(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy,
         mock_hierarchy,
         mock_backend_class,
@@ -644,10 +759,12 @@ class TestDeploySingleFile:
         mock_hierarchy.return_value = ("parent123", [("docs/my-dir", "dir-pid", "My Dir")])
         mock_deploy.return_value = "deployed-page-id"
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
 
-        with patch("sys.argv", _base_deploy_argv(test_file)):
+        with patch("sys.argv", _base_apply_argv(test_file)):
             main.main()
 
         # set_page called once for the hierarchy container + once for the page itself
@@ -661,12 +778,14 @@ class TestDeploySingleFile:
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
     @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_state_not_saved_when_deploy_returns_none(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy,
         mock_hierarchy,
         mock_backend_class,
@@ -684,12 +803,14 @@ class TestDeploySingleFile:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None  # page skipped
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_file)):
+        with patch("sys.argv", _base_apply_argv(test_file)):
             main.main()
 
         mock_state.set_page.assert_not_called()
@@ -700,12 +821,14 @@ class TestDeploySingleFile:
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
     @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_file_with_custom_docs_root(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy,
         mock_hierarchy,
         mock_backend_class,
@@ -725,6 +848,8 @@ class TestDeploySingleFile:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
@@ -732,7 +857,7 @@ class TestDeploySingleFile:
 
         with patch(
             "sys.argv",
-            _base_deploy_argv(
+            _base_apply_argv(
                 test_file,
                 extra=["--docs-root", str(custom_root)],
             ),
@@ -746,12 +871,14 @@ class TestDeploySingleFile:
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
     @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_file_with_git_repo_url(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy,
         mock_hierarchy,
         mock_backend_class,
@@ -769,6 +896,8 @@ class TestDeploySingleFile:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
@@ -777,7 +906,7 @@ class TestDeploySingleFile:
         git_url = "https://github.com/user/repo"
         with patch(
             "sys.argv",
-            _base_deploy_argv(
+            _base_apply_argv(
                 test_file,
                 extra=["--git-repo-url", git_url],
             ),
@@ -792,12 +921,14 @@ class TestDeploySingleFile:
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
     @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_file_with_hierarchy(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy,
         mock_hierarchy,
         mock_backend_class,
@@ -818,6 +949,8 @@ class TestDeploySingleFile:
         mock_hierarchy.return_value = ("parent123", [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
@@ -825,7 +958,7 @@ class TestDeploySingleFile:
 
         with patch(
             "sys.argv",
-            _base_deploy_argv(
+            _base_apply_argv(
                 test_file,
                 extra=["--docs-root", str(docs_root)],
             ),
@@ -837,44 +970,50 @@ class TestDeploySingleFile:
 
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — live directory deployment
+# Apply subcommand — directory deployment
 # ---------------------------------------------------------------------------
 
 
-class TestDeployDirectory:
-    """Test directory live deployment (with lock)."""
+class TestApplyDirectory:
+    """Test directory live deployment via apply (with lock)."""
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_directory_deployment(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy_tree,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
         tmp_path,
     ):
-        """Deploy a directory: calls deploy_tree."""
+        """Apply a directory: calls deploy_tree."""
         test_dir = tmp_path / "docs"
         test_dir.mkdir()
+        f1 = test_dir / "page.md"
+        f1.write_text("# Page")
 
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
         mock_deploy_tree.return_value = ([], [])
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_dir, is_dir=True)):
+        with patch("sys.argv", _base_apply_argv(test_dir, is_dir=True)):
             main.main()
 
         mock_deploy_tree.assert_called_once()
@@ -883,12 +1022,14 @@ class TestDeployDirectory:
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_state_saved_for_each_deployed_page_in_tree(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy_tree,
         mock_backend_class,
         mock_state_class,
@@ -908,12 +1049,14 @@ class TestDeployDirectory:
         mock_api_class.return_value = mock_api
         mock_deploy_tree.return_value = ([(f1, "pid1"), (f2, "pid2")], [])
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1, f2])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(docs, is_dir=True)):
+        with patch("sys.argv", _base_apply_argv(docs, is_dir=True)):
             main.main()
 
         assert mock_state.set_page.call_count == 2
@@ -923,12 +1066,14 @@ class TestDeployDirectory:
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_hierarchy_pages_tracked_in_state_for_tree(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy_tree,
         mock_backend_class,
         mock_state_class,
@@ -949,10 +1094,12 @@ class TestDeployDirectory:
             [("docs/sub", "sub-pid", "Sub")],
         )
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
 
-        with patch("sys.argv", _base_deploy_argv(docs, is_dir=True)):
+        with patch("sys.argv", _base_apply_argv(docs, is_dir=True)):
             main.main()
 
         # 1 hierarchy page + 1 content page
@@ -965,12 +1112,14 @@ class TestDeployDirectory:
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_state_skips_none_page_ids_in_tree(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy_tree,
         mock_backend_class,
         mock_state_class,
@@ -990,12 +1139,14 @@ class TestDeployDirectory:
         mock_api_class.return_value = mock_api
         mock_deploy_tree.return_value = ([(f1, "pid-ok"), (f2, None)], [])
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1, f2])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(docs, is_dir=True)):
+        with patch("sys.argv", _base_apply_argv(docs, is_dir=True)):
             main.main()
 
         assert mock_state.set_page.call_count == 1
@@ -1005,12 +1156,14 @@ class TestDeployDirectory:
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_tree_with_git_repo_url(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy_tree,
         mock_backend_class,
         mock_state_class,
@@ -1020,11 +1173,15 @@ class TestDeployDirectory:
         """--git-repo-url is passed through to deploy_tree."""
         test_dir = tmp_path / "docs"
         test_dir.mkdir()
+        f1 = test_dir / "page.md"
+        f1.write_text("# Page")
 
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
         mock_deploy_tree.return_value = ([], [])
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1])
 
         mock_state = Mock()
         mock_state_class.return_value = mock_state
@@ -1034,7 +1191,7 @@ class TestDeployDirectory:
         git_url = "https://github.com/user/repo"
         with patch(
             "sys.argv",
-            _base_deploy_argv(
+            _base_apply_argv(
                 test_dir,
                 is_dir=True,
                 extra=["--git-repo-url", git_url],
@@ -1045,414 +1202,441 @@ class TestDeployDirectory:
         call_args = mock_deploy_tree.call_args[0]
         assert call_args[4] == git_url
 
-
-# ---------------------------------------------------------------------------
-# Deploy subcommand — --changed-only
-# ---------------------------------------------------------------------------
-
-
-class TestDeployChangedOnly:
-    """Test deploy --changed-only."""
-
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
     @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_changed_only_prints_count_message(
+    def test_apply_force_flag_passed_to_compute_plan(
         self,
         mock_api_class,
         mock_find_mgmt,
+        mock_compute_plan,
         mock_deploy_tree,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
         tmp_path,
-        capsys,
     ):
-        """--changed-only prints the count of changed files."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        changed = docs / "changed.md"
-        unchanged = docs / "unchanged.md"
-        changed.write_text("# New Content")
-        unchanged.write_text("# Old Content")
+        """--force is passed to compute_plan on apply."""
+        test_dir = tmp_path / "docs"
+        test_dir.mkdir()
+        f1 = test_dir / "page.md"
+        f1.write_text("# Page")
 
         mock_api = Mock()
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
         mock_deploy_tree.return_value = ([], [])
 
-        # State mock: changed.md has_changed=True, unchanged.md has_changed=False
-        mock_state = Mock()
-        mock_state.has_changed.side_effect = lambda rel, f: f.name == "changed.md"
-        mock_state_class.return_value = mock_state
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1])
 
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
         with patch(
             "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--changed-only"],
-            ),
+            _base_apply_argv(test_dir, is_dir=True, extra=["--force"]),
         ):
             main.main()
 
-        captured = capsys.readouterr()
-        assert "--changed-only: 1 file(s) with changes" in captured.out
-
-        # deploy_tree must receive only the changed file via files= kwarg
-        mock_deploy_tree.assert_called_once()
-        call_kwargs = mock_deploy_tree.call_args
-        files_arg = call_kwargs[1].get("files") if call_kwargs[1] else None
-        assert files_arg is not None, "deploy_tree must be called with files= when --changed-only"
-        file_names = [f.name for f in files_arg]
-        assert "changed.md" in file_names
-        assert "unchanged.md" not in file_names
-
-    @patch("ccfm_convert.main.LockManager")
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_tree")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_zero_changes_does_not_call_deploy_tree(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_deploy_tree,
-        mock_backend_class,
-        mock_state_class,
-        mock_lock_class,
-        tmp_path,
-        capsys,
-    ):
-        """When --changed-only reports 0 changes, deploy_tree must not be called."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        unchanged = docs / "unchanged.md"
-        unchanged.write_text("# Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-
-        # All files report as unchanged
-        mock_state = Mock()
-        mock_state.has_changed.return_value = False
-        mock_state_class.return_value = mock_state
-
-        mock_lock = Mock()
-        mock_lock_class.return_value = mock_lock
-
-        with patch(
-            "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--changed-only"],
-            ),
-        ):
-            main.main()
-
-        mock_deploy_tree.assert_not_called()
-        mock_lock.acquire.assert_not_called()
-        captured = capsys.readouterr()
-        assert "No changes to deploy" in captured.out
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.LockManager")
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_tree")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_zero_changes_does_not_archive_pages(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_deploy_tree,
-        mock_backend_class,
-        mock_state_class,
-        mock_lock_class,
-        mock_archive,
-        tmp_path,
-    ):
-        """When --changed-only reports 0 changes, --archive-orphans must not run."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        unchanged = docs / "unchanged.md"
-        unchanged.write_text("# Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-
-        mock_state = Mock()
-        mock_state.has_changed.return_value = False
-        mock_state_class.return_value = mock_state
-
-        mock_lock = Mock()
-        mock_lock_class.return_value = mock_lock
-
-        with patch(
-            "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--changed-only", "--archive-orphans"],
-            ),
-        ):
-            main.main()
-
-        mock_deploy_tree.assert_not_called()
-        mock_archive.assert_not_called()
+        call_kwargs = mock_compute_plan.call_args[1]
+        assert call_kwargs["force"] is True
 
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — --archive-orphans
+# Apply subcommand — confirmation prompt
 # ---------------------------------------------------------------------------
 
 
-class TestDeployArchiveOrphans:
-    """Test deploy --archive-orphans during live deployment."""
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.LockManager")
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_tree")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_archive_orphans_calls_archive_and_removes_from_state(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_deploy_tree,
-        mock_backend_class,
-        mock_state_class,
-        mock_lock_class,
-        mock_archive,
-        tmp_path,
-    ):
-        """Orphaned pages are archived and removed from state."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        active = docs / "active.md"
-        active.write_text("# Active")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = ([(active, "active-pid")], [])
-
-        mock_state = Mock()
-        mock_state.find_orphans.return_value = ["docs/deleted.md"]
-        mock_state.get_page.return_value = {"page_id": "orphan-pid", "title": "Deleted"}
-        mock_state_class.return_value = mock_state
-
-        mock_archive.return_value = True
-
-        mock_lock = Mock()
-        mock_lock_class.return_value = mock_lock
-
-        with patch(
-            "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--archive-orphans"],
-            ),
-        ):
-            main.main()
-
-        mock_archive.assert_called_once_with(mock_api, "orphan-pid", "Deleted")
-        mock_state.remove_page.assert_called_once_with("docs/deleted.md")
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.LockManager")
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_tree")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_archive_orphans_no_orphans_prints_message(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_deploy_tree,
-        mock_backend_class,
-        mock_state_class,
-        mock_lock_class,
-        mock_archive,
-        tmp_path,
-        capsys,
-    ):
-        """When no orphans found, prints info message."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        active = docs / "active.md"
-        active.write_text("# Active")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = ([(active, "active-pid")], [])
-
-        mock_state = Mock()
-        mock_state.find_orphans.return_value = []
-        mock_state_class.return_value = mock_state
-
-        mock_lock = Mock()
-        mock_lock_class.return_value = mock_lock
-
-        with patch(
-            "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--archive-orphans"],
-            ),
-        ):
-            main.main()
-
-        captured = capsys.readouterr()
-        assert "No orphaned pages found" in captured.out
-        mock_archive.assert_not_called()
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.LockManager")
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_tree")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_archive_failure_does_not_remove_from_state(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_deploy_tree,
-        mock_backend_class,
-        mock_state_class,
-        mock_lock_class,
-        mock_archive,
-        tmp_path,
-    ):
-        """If archive_page returns False, entry stays in state."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = ([], [])
-
-        mock_state = Mock()
-        mock_state.find_orphans.return_value = ["docs/orphan.md"]
-        mock_state.get_page.return_value = {"page_id": "orphan-id", "title": "Orphan"}
-        mock_state_class.return_value = mock_state
-
-        mock_archive.return_value = False  # simulate archive failure
-
-        mock_lock = Mock()
-        mock_lock_class.return_value = mock_lock
-
-        with patch(
-            "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--archive-orphans"],
-            ),
-        ):
-            main.main()
-
-        mock_archive.assert_called_once()
-        mock_state.remove_page.assert_not_called()
-
-    @patch("ccfm_convert.main.archive_page")
-    @patch("ccfm_convert.main.LockManager")
-    @patch("ccfm_convert.main.StateManager")
-    @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_tree")
-    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
-    @patch("ccfm_convert.main.ConfluenceAPI")
-    def test_changed_only_with_archive_orphans_uses_all_files(
-        self,
-        mock_api_class,
-        mock_find_mgmt,
-        mock_deploy_tree,
-        mock_backend_class,
-        mock_state_class,
-        mock_lock_class,
-        mock_archive,
-        tmp_path,
-    ):
-        """--changed-only + --archive-orphans: orphan detection uses all disk files."""
-        docs = tmp_path / "docs"
-        docs.mkdir()
-        changed = docs / "changed.md"
-        unchanged = docs / "unchanged.md"
-        changed.write_text("# New Content")
-        unchanged.write_text("# Stable Content")
-
-        mock_api = Mock()
-        mock_api.get_space_id.return_value = "space123"
-        mock_api_class.return_value = mock_api
-        mock_deploy_tree.return_value = ([(changed, "changed-pid")], [])
-
-        mock_state = Mock()
-        mock_state.has_changed.side_effect = lambda rel, f: "changed" in str(f)
-        mock_state.find_orphans.return_value = []
-        mock_state_class.return_value = mock_state
-
-        mock_lock = Mock()
-        mock_lock_class.return_value = mock_lock
-
-        with patch(
-            "sys.argv",
-            _base_deploy_argv(
-                docs,
-                is_dir=True,
-                extra=["--changed-only", "--archive-orphans"],
-            ),
-        ):
-            main.main()
-
-        # find_orphans should receive all_files (both changed and unchanged)
-        call_args = mock_state.find_orphans.call_args[0]
-        all_files_passed = call_args[0]
-        filenames = {f.name for f in all_files_passed}
-        assert "changed.md" in filenames
-        assert "unchanged.md" in filenames
-        mock_archive.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Deploy subcommand — locking
-# ---------------------------------------------------------------------------
-
-
-class TestDeployLocking:
-    """Test deploy lock acquisition and release."""
+class TestApplyConfirmation:
+    """Test apply confirmation prompt behavior."""
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_auto_approve_skips_prompt(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """--auto-approve does not call input()."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("builtins.input") as mock_input:
+            with patch("sys.argv", _base_apply_argv(test_file)):
+                main.main()
+
+            mock_input.assert_not_called()
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_non_tty_without_auto_approve_exits(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+        capsys,
+    ):
+        """Non-TTY stdin without --auto-approve exits 1."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
+        # argv WITHOUT --auto-approve
+        argv = [
+            "main.py",
+            "--domain",
+            "example.atlassian.net",
+            "--email",
+            "test@example.com",
+            "--token",
+            "token",
+            "--space",
+            "TEST",
+            "apply",
+            "--file",
+            str(test_file),
+        ]
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                with patch("sys.argv", argv):
+                    main.main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--auto-approve" in captured.out
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_tty_prompt_accepted(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """'yes' input at TTY prompt proceeds with apply."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        argv = [
+            "main.py",
+            "--domain",
+            "example.atlassian.net",
+            "--email",
+            "test@example.com",
+            "--token",
+            "token",
+            "--space",
+            "TEST",
+            "apply",
+            "--file",
+            str(test_file),
+        ]
+
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            with patch("builtins.input", return_value="yes"):
+                with patch("sys.argv", argv):
+                    main.main()
+
+        # Deploy should proceed
+        mock_lock.acquire.assert_called_once()
+        mock_state.save.assert_called_once()
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_tty_prompt_rejected(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+        capsys,
+    ):
+        """'no' input at TTY prompt cancels and prints 'Apply cancelled.'."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
+        argv = [
+            "main.py",
+            "--domain",
+            "example.atlassian.net",
+            "--email",
+            "test@example.com",
+            "--token",
+            "token",
+            "--space",
+            "TEST",
+            "apply",
+            "--file",
+            str(test_file),
+        ]
+
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            with patch("builtins.input", return_value="no"):
+                with patch("sys.argv", argv):
+                    main.main()
+
+        captured = capsys.readouterr()
+        assert "Apply cancelled." in captured.out
+
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_no_changes_skips_prompt(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        tmp_path,
+        capsys,
+    ):
+        """When plan has no changes, no prompt is shown."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_compute_plan.return_value = _mock_plan_no_changes()
+
+        argv = [
+            "main.py",
+            "--domain",
+            "example.atlassian.net",
+            "--email",
+            "test@example.com",
+            "--token",
+            "token",
+            "--space",
+            "TEST",
+            "apply",
+            "--file",
+            str(test_file),
+        ]
+
+        with patch("builtins.input") as mock_input:
+            with patch("sys.argv", argv):
+                main.main()
+
+            mock_input.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "No changes to apply." in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Apply subcommand — destroy handling
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDestroy:
+    """Test apply destroy page behavior."""
+
+    @patch("ccfm_convert.main.destroy_pages")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_apply_calls_destroy_pages_when_destroys_exist(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_destroy_pages,
+        tmp_path,
+        capsys,
+    ):
+        """destroy_pages is called when plan has destroy actions."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+
+        mock_plan = Mock()
+        mock_plan.has_changes.return_value = True
+        # No actionable page_actions (all no-op), but has destroy actions
+        noop_action = Mock()
+        noop_action.action = "no-op"
+        mock_plan.page_actions = [noop_action]
+        destroy_action = Mock()
+        destroy_action.rel_path = "docs/deleted.md"
+        destroy_action.page_id = "orphan-pid"
+        destroy_action.title = "Deleted"
+        mock_plan.destroy_actions = [destroy_action]
+        mock_compute_plan.return_value = mock_plan
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_apply_argv(test_file)):
+            main.main()
+
+        mock_destroy_pages.assert_called_once_with(mock_api, mock_state, [destroy_action])
+        captured = capsys.readouterr()
+        assert "Destroying 1 page(s)" in captured.out
+
+    @patch("ccfm_convert.main.destroy_pages")
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_apply_no_destroys_skips_destroy(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_deploy,
+        mock_hierarchy,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        mock_destroy_pages,
+        tmp_path,
+    ):
+        """destroy_pages is not called when plan has no destroy actions."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_hierarchy.return_value = (None, [])
+        mock_deploy.return_value = None
+
+        mock_plan = _mock_plan_with_changes([test_file])
+        mock_plan.destroy_actions = []
+        mock_compute_plan.return_value = mock_plan
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch("sys.argv", _base_apply_argv(test_file)):
+            main.main()
+
+        mock_destroy_pages.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Apply subcommand — locking
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLocking:
+    """Test apply lock acquisition and release."""
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_lock_error_exits_with_code_1(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
-        mock_deploy,
+        mock_compute_plan,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -1468,6 +1652,8 @@ class TestDeployLocking:
         mock_api.get_space_id.return_value = "space123"
         mock_api_class.return_value = mock_api
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
 
@@ -1476,7 +1662,7 @@ class TestDeployLocking:
         mock_lock_class.return_value = mock_lock
 
         with pytest.raises(SystemExit) as exc_info:
-            with patch("sys.argv", _base_deploy_argv(test_file)):
+            with patch("sys.argv", _base_apply_argv(test_file)):
                 main.main()
 
         assert exc_info.value.code == 1
@@ -1484,16 +1670,18 @@ class TestDeployLocking:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_lock_released_even_on_deploy_error(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -1509,6 +1697,8 @@ class TestDeployLocking:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.side_effect = RuntimeError("deploy failed")
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
 
@@ -1516,7 +1706,7 @@ class TestDeployLocking:
         mock_lock_class.return_value = mock_lock
 
         with pytest.raises(RuntimeError):
-            with patch("sys.argv", _base_deploy_argv(test_file)):
+            with patch("sys.argv", _base_apply_argv(test_file)):
                 main.main()
 
         mock_lock.release.assert_called_once()
@@ -1524,16 +1714,18 @@ class TestDeployLocking:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_lock_id_passed_to_acquire(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -1549,6 +1741,8 @@ class TestDeployLocking:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
 
@@ -1557,18 +1751,18 @@ class TestDeployLocking:
 
         with patch(
             "sys.argv",
-            _base_deploy_argv(
+            _base_apply_argv(
                 test_file,
                 extra=["--lock-id", "ci-run-42"],
             ),
         ):
             main.main()
 
-        mock_lock.acquire.assert_called_once_with(operation="deploy", lock_id="ci-run-42")
+        mock_lock.acquire.assert_called_once_with(operation="apply", lock_id="ci-run-42")
 
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — management page not found
+# Apply subcommand — management page not found
 # ---------------------------------------------------------------------------
 
 
@@ -1587,7 +1781,7 @@ class TestManagementPageDiscovery:
         mock_api_class.return_value = mock_api
 
         with pytest.raises(SystemExit) as exc_info:
-            with patch("sys.argv", _base_deploy_argv(test_file)):
+            with patch("sys.argv", _base_apply_argv(test_file)):
                 main.main()
 
         assert exc_info.value.code == 1
@@ -1605,7 +1799,7 @@ class TestManagementPageDiscovery:
         mock_api_class.return_value = mock_api
 
         with pytest.raises(SystemExit) as exc_info:
-            with patch("sys.argv", _base_deploy_argv(test_file)):
+            with patch("sys.argv", _base_apply_argv(test_file)):
                 main.main()
 
         assert exc_info.value.code == 1
@@ -1613,14 +1807,16 @@ class TestManagementPageDiscovery:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_find_management_page_returns_page_id(
         self,
         mock_api_class,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -1638,12 +1834,14 @@ class TestManagementPageDiscovery:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_file)):
+        with patch("sys.argv", _base_apply_argv(test_file)):
             main.main()
 
         # ConfluenceBackend should have been called with the found mgmt page id
@@ -1651,18 +1849,19 @@ class TestManagementPageDiscovery:
 
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — output
+# Apply subcommand — output
 # ---------------------------------------------------------------------------
 
 
-class TestDeployOutput:
-    """Test deploy CLI output messages."""
+class TestApplyOutput:
+    """Test apply CLI output messages."""
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     @patch("sys.stdout", new_callable=StringIO)
@@ -1671,14 +1870,15 @@ class TestDeployOutput:
         mock_stdout,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
         tmp_path,
     ):
-        """Success message output includes 'Deployment complete'."""
+        """Success message output includes 'Apply complete'."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -1688,22 +1888,25 @@ class TestDeployOutput:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_file)):
+        with patch("sys.argv", _base_apply_argv(test_file)):
             main.main()
 
         output = mock_stdout.getvalue()
-        assert "Deployment complete" in output
+        assert "Apply complete" in output
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     @patch("sys.stdout", new_callable=StringIO)
@@ -1712,14 +1915,15 @@ class TestDeployOutput:
         mock_stdout,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
         tmp_path,
     ):
-        """Space ID is printed during deployment."""
+        """Space ID is printed during apply."""
         test_file = tmp_path / "test.md"
         test_file.write_text("# Test")
 
@@ -1729,12 +1933,14 @@ class TestDeployOutput:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_file)):
+        with patch("sys.argv", _base_apply_argv(test_file)):
             main.main()
 
         output = mock_stdout.getvalue()
@@ -1742,12 +1948,12 @@ class TestDeployOutput:
 
 
 # ---------------------------------------------------------------------------
-# Deploy subcommand — error handling
+# Apply subcommand — error handling
 # ---------------------------------------------------------------------------
 
 
-class TestDeployErrorHandling:
-    """Test error handling during deployment."""
+class TestApplyErrorHandling:
+    """Test error handling during apply."""
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
@@ -1772,7 +1978,59 @@ class TestDeployErrorHandling:
         mock_api_class.return_value = mock_api
 
         with pytest.raises(ValueError):
-            with patch("sys.argv", _base_deploy_argv(test_file)):
+            with patch("sys.argv", _base_apply_argv(test_file)):
+                main.main()
+
+    def test_apply_missing_file_exits(self, tmp_path):
+        """Apply with --file pointing to nonexistent file exits 1."""
+        missing = tmp_path / "nonexistent.md"
+        with pytest.raises(SystemExit):
+            with patch("sys.argv", _base_apply_argv(missing)):
+                main.main()
+
+    def test_apply_missing_directory_exits(self, tmp_path):
+        """Apply with --directory pointing to nonexistent dir exits 1."""
+        missing_dir = tmp_path / "no-such-dir"
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "token",
+                    "--space",
+                    "TEST",
+                    "apply",
+                    "--directory",
+                    str(missing_dir),
+                    "--auto-approve",
+                ],
+            ):
+                main.main()
+
+    def test_apply_no_file_or_directory_exits(self):
+        """Apply without --file or --directory exits 1."""
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                [
+                    "main.py",
+                    "--domain",
+                    "example.atlassian.net",
+                    "--email",
+                    "test@example.com",
+                    "--token",
+                    "token",
+                    "--space",
+                    "TEST",
+                    "apply",
+                    "--auto-approve",
+                ],
+            ):
                 main.main()
 
 
@@ -2510,16 +2768,18 @@ class TestConfigFileLoading:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_config_file_loaded_when_ccfm_yaml_present(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -2540,6 +2800,8 @@ class TestConfigFileLoading:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
@@ -2554,7 +2816,8 @@ class TestConfigFileLoading:
                     "main.py",
                     "--token",
                     "tok",
-                    "deploy",
+                    "apply",
+                    "--auto-approve",
                     "--file",
                     str(test_file),
                 ],
@@ -2584,7 +2847,8 @@ class TestConfigFileLoading:
                         "tok",
                         "--config",
                         str(config_file),
-                        "deploy",
+                        "apply",
+                        "--auto-approve",
                         "--file",
                         "test.md",
                     ],
@@ -2598,16 +2862,18 @@ class TestConfigFileLoading:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_explicit_config_flag_loads_named_file(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -2628,6 +2894,8 @@ class TestConfigFileLoading:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
@@ -2641,7 +2909,8 @@ class TestConfigFileLoading:
                 "tok",
                 "--config",
                 str(custom_config),
-                "deploy",
+                "apply",
+                "--auto-approve",
                 "--file",
                 str(test_file),
             ],
@@ -2662,16 +2931,18 @@ class TestTokenHandling:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_token_from_env_var(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -2686,6 +2957,8 @@ class TestTokenHandling:
         mock_api_class.return_value = mock_api
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
 
         mock_state = Mock()
         mock_state_class.return_value = mock_state
@@ -2703,7 +2976,8 @@ class TestTokenHandling:
                     "test@example.com",
                     "--space",
                     "TEST",
-                    "deploy",
+                    "apply",
+                    "--auto-approve",
                     "--file",
                     str(test_file),
                 ],
@@ -2728,7 +3002,8 @@ class TestTokenHandling:
                         "test@example.com",
                         "--space",
                         "TEST",
-                        "deploy",
+                        "apply",
+                        "--auto-approve",
                         "--file",
                         "test.md",
                     ],
@@ -2747,16 +3022,18 @@ class TestPathHandling:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_relative_path(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -2776,6 +3053,8 @@ class TestPathHandling:
             mock_hierarchy.return_value = (None, [])
             mock_deploy.return_value = None
 
+            mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
             mock_state = Mock()
             mock_state_class.return_value = mock_state
             mock_lock = Mock()
@@ -2793,7 +3072,8 @@ class TestPathHandling:
                     "token",
                     "--space",
                     "TEST",
-                    "deploy",
+                    "apply",
+                    "--auto-approve",
                     "--file",
                     "test.md",
                 ],
@@ -2807,16 +3087,18 @@ class TestPathHandling:
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")
     @patch("ccfm_convert.main.ConfluenceBackend")
-    @patch("ccfm_convert.main.deploy_page")
     @patch("ccfm_convert.main.ensure_page_hierarchy")
+    @patch("ccfm_convert.main.deploy_page")
+    @patch("ccfm_convert.main.compute_plan")
     @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
     @patch("ccfm_convert.main.ConfluenceAPI")
     def test_absolute_path(
         self,
         mock_api_class,
         mock_find_mgmt,
-        mock_hierarchy,
+        mock_compute_plan,
         mock_deploy,
+        mock_hierarchy,
         mock_backend_class,
         mock_state_class,
         mock_lock_class,
@@ -2832,12 +3114,14 @@ class TestPathHandling:
         mock_hierarchy.return_value = (None, [])
         mock_deploy.return_value = None
 
+        mock_compute_plan.return_value = _mock_plan_with_changes([test_file])
+
         mock_state = Mock()
         mock_state_class.return_value = mock_state
         mock_lock = Mock()
         mock_lock_class.return_value = mock_lock
 
-        with patch("sys.argv", _base_deploy_argv(test_file.absolute())):
+        with patch("sys.argv", _base_apply_argv(test_file.absolute())):
             main.main()
 
         mock_deploy.assert_called_once()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -5,9 +5,12 @@ from unittest.mock import Mock
 import pytest
 
 from ccfm_convert.deploy.orchestration import (
-    archive_page,
     deploy_page,
     deploy_tree,
+    destroy_page,
+    destroy_pages,
+    dump_page,
+    dump_tree,
     ensure_page_hierarchy,
 )
 
@@ -289,22 +292,6 @@ ci_banner: false
 
         # Should still create page successfully
         assert mock_api.create_page.called
-
-    def test_deploy_dump_mode(self, mock_api, tmp_path):
-        """Test dump mode (no deployment)."""
-        filepath = tmp_path / "test.md"
-        filepath.write_text("# Test")
-
-        page_id = deploy_page(mock_api, "space123", None, filepath, dump=True)
-
-        assert page_id is None
-        # Should not call any API methods
-        mock_api.create_page.assert_not_called()
-        mock_api.update_page.assert_not_called()
-
-        # Should create .adf.json file
-        adf_file = filepath.with_suffix(".adf.json")
-        assert adf_file.exists()
 
     def test_deploy_with_git_url(self, mock_api, tmp_path):
         """Test deploying with git URL."""
@@ -672,19 +659,6 @@ class TestDeployTree:
         # Plus one for the container page created from .page_content.md
         assert mock_api.create_page.call_count >= 1
 
-    def test_deploy_tree_dump_mode_skips_hierarchy(self, mock_api, tmp_path):
-        """Line 147: in dump mode deploy_tree sets parent_id=None without calling ensure_page_hierarchy."""
-        docs_root = tmp_path / "docs"
-        docs_root.mkdir()
-        file1 = docs_root / "test.md"
-        file1.write_text("# Test")
-
-        deploy_tree(mock_api, "space123", docs_root, docs_root, dump=True)
-
-        # In dump mode, hierarchy should NOT be built and no API create/update calls
-        mock_api.create_page.assert_not_called()
-        mock_api.update_page.assert_not_called()
-
     def test_deploy_error_handling(self, mock_api, tmp_path):
         """Test error handling during deployment."""
         docs_root = tmp_path / "docs"
@@ -891,43 +865,271 @@ invalid yaml:
         assert page_id == "page-123"
 
 
-class TestArchivePage:
-    """Tests for archive_page.
+class TestDestroyPage:
+    """Tests for destroy_page.
 
-    archive_page uses api.delete_page() (v2 DELETE) because the Confluence Cloud
-    v2 PUT endpoint only accepts CURRENT or DRAFT as status values — 'archived'
-    is rejected with a 400 error. DELETE moves the page to the site trash, which
-    is the closest available equivalent to archiving via the API.
+    destroy_page uses api.delete_page() (v2 DELETE) because the Confluence Cloud
+    v2 PUT endpoint only accepts CURRENT or DRAFT as status values. DELETE moves
+    the page to the site trash.
     """
 
-    def test_archive_page_success_returns_true(self, mock_api):
-        """archive_page calls api.delete_page and returns True on success."""
-        result = archive_page(mock_api, "page-42", "My Page")
+    def test_destroy_page_success_returns_true(self, mock_api):
+        """destroy_page calls api.delete_page and returns True on success."""
+        result = destroy_page(mock_api, "page-42", "My Page")
 
         assert result is True
         mock_api.delete_page.assert_called_once_with("page-42")
 
-    def test_archive_page_exception_returns_false(self, mock_api):
-        """archive_page catches exceptions from delete_page and returns False."""
+    def test_destroy_page_exception_returns_false(self, mock_api):
+        """destroy_page catches exceptions from delete_page and returns False."""
         mock_api.delete_page.side_effect = RuntimeError("API down")
 
-        result = archive_page(mock_api, "page-99", "Broken Page")
+        result = destroy_page(mock_api, "page-99", "Broken Page")
 
         assert result is False
 
-    def test_archive_page_prints_success_message(self, mock_api, capsys):
-        """archive_page prints confirmation with title and page_id on success."""
-        archive_page(mock_api, "page-1", "Published Title")
+    def test_destroy_page_prints_success_message(self, mock_api, capsys):
+        """destroy_page prints confirmation with title and page_id on success."""
+        destroy_page(mock_api, "page-1", "Published Title")
 
         captured = capsys.readouterr()
         assert "Published Title" in captured.out
         assert "page-1" in captured.out
 
-    def test_archive_page_prints_warning_on_failure(self, mock_api, capsys):
-        """archive_page prints a warning on failure."""
+    def test_destroy_page_prints_warning_on_failure(self, mock_api, capsys):
+        """destroy_page prints a warning on failure."""
         mock_api.delete_page.side_effect = RuntimeError("timeout")
 
-        archive_page(mock_api, "page-2", "Failed Page")
+        destroy_page(mock_api, "page-2", "Failed Page")
 
         captured = capsys.readouterr()
         assert "Failed Page" in captured.out
+
+
+class TestDestroyPages:
+    """Tests for destroy_pages — batch destroy with state removal."""
+
+    def test_destroy_pages_deletes_and_removes_from_state(self, mock_api):
+        """destroy_pages calls destroy_page for each action and removes from state."""
+        from ccfm_convert.plan.planner import DestroyAction
+
+        state = Mock()
+        actions = [
+            DestroyAction(rel_path="docs/page.md", page_id="p1", title="Page"),
+        ]
+
+        count = destroy_pages(mock_api, state, actions)
+
+        assert count == 1
+        mock_api.delete_page.assert_called_once_with("p1")
+        state.remove_page.assert_called_once_with("docs/page.md")
+
+    def test_destroy_pages_preserves_order(self, mock_api):
+        """destroy_pages executes in the order provided (planner pre-sorts deepest-first)."""
+        from ccfm_convert.plan.planner import DestroyAction
+
+        state = Mock()
+        # Pre-sorted deepest-first by the planner
+        actions = [
+            DestroyAction(rel_path="docs/team/sub/page.md", page_id="p1", title="Page"),
+            DestroyAction(rel_path="docs/team/sub", page_id="d2", title="Sub"),
+            DestroyAction(rel_path="docs/team", page_id="d1", title="Team"),
+        ]
+
+        delete_order = []
+        mock_api.delete_page.side_effect = lambda pid: delete_order.append(pid)
+
+        destroy_pages(mock_api, state, actions)
+
+        assert delete_order == ["p1", "d2", "d1"]
+
+    def test_destroy_pages_partial_failure(self, mock_api):
+        """destroy_pages continues on failure and only removes successful entries from state."""
+        from ccfm_convert.plan.planner import DestroyAction
+
+        state = Mock()
+        actions = [
+            DestroyAction(rel_path="docs/a.md", page_id="p1", title="A"),
+            DestroyAction(rel_path="docs/b.md", page_id="p2", title="B"),
+        ]
+
+        # First succeeds, second fails
+        mock_api.delete_page.side_effect = [None, RuntimeError("fail")]
+
+        count = destroy_pages(mock_api, state, actions)
+
+        assert count == 1
+        state.remove_page.assert_called_once_with("docs/a.md")
+
+    def test_destroy_pages_empty_list(self, mock_api):
+        """destroy_pages with empty list returns 0."""
+        state = Mock()
+        count = destroy_pages(mock_api, state, [])
+
+        assert count == 0
+        mock_api.delete_page.assert_not_called()
+
+
+class TestDumpPage:
+    """Tests for dump_page — local ADF generation without API calls."""
+
+    def test_dump_page_writes_adf(self, tmp_path, monkeypatch):
+        """dump_page writes .adf.json file to output directory."""
+        monkeypatch.chdir(tmp_path)
+        filepath = tmp_path / "test.md"
+        filepath.write_text("# Hello World")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = dump_page(filepath, output_dir)
+
+        assert result is not None
+        assert result.exists()
+        assert result.suffix == ".json"
+        import json
+
+        data = json.loads(result.read_text())
+        assert data["type"] == "doc"
+
+    def test_dump_page_preserves_relative_path(self, tmp_path, monkeypatch):
+        """dump_page mirrors source tree structure in output directory."""
+        monkeypatch.chdir(tmp_path)
+        docs_dir = tmp_path / "docs" / "team"
+        docs_dir.mkdir(parents=True)
+        filepath = docs_dir / "api.md"
+        filepath.write_text("# API")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = dump_page(filepath, output_dir)
+
+        assert result is not None
+        assert "docs/team/api.adf.json" in str(result)
+
+    def test_dump_page_skips_deploy_page_false(self, tmp_path, monkeypatch):
+        """dump_page returns None for files with deploy_page: false."""
+        monkeypatch.chdir(tmp_path)
+        filepath = tmp_path / "test.md"
+        filepath.write_text("---\ndeploy_config:\n  deploy_page: false\n---\n# Skip")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = dump_page(filepath, output_dir)
+
+        assert result is None
+
+    def test_dump_page_with_git_repo_url(self, tmp_path, monkeypatch):
+        """dump_page passes git_repo_url for CI banner generation."""
+        monkeypatch.chdir(tmp_path)
+        filepath = tmp_path / "test.md"
+        filepath.write_text("# Test")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = dump_page(filepath, output_dir, git_repo_url="https://github.com/org/repo")
+
+        assert result is not None
+        assert result.exists()
+
+    def test_dump_page_write_error(self, tmp_path, monkeypatch):
+        """dump_page returns None on write failure."""
+        monkeypatch.chdir(tmp_path)
+        filepath = tmp_path / "test.md"
+        filepath.write_text("# Test")
+        # output_dir is a file, not a directory — will cause write error
+        output_dir = tmp_path / "blocker"
+        output_dir.write_text("not a dir")
+
+        result = dump_page(filepath, output_dir)
+
+        assert result is None
+
+    def test_dump_page_no_page_link_resolution(self, tmp_path, monkeypatch):
+        """dump_page does NOT call resolve_page_links (no API needed)."""
+        monkeypatch.chdir(tmp_path)
+        filepath = tmp_path / "test.md"
+        filepath.write_text("# Test with [link](<Some Page>)")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        # This should NOT crash — no API is passed, resolve_page_links is not called
+        result = dump_page(filepath, output_dir)
+
+        assert result is not None
+        assert result.exists()
+
+    def test_dump_page_filepath_outside_cwd(self, tmp_path, monkeypatch):
+        """dump_page falls back to filename when filepath is outside cwd."""
+        cwd_dir = tmp_path / "workdir"
+        cwd_dir.mkdir()
+        monkeypatch.chdir(cwd_dir)
+
+        other_dir = tmp_path / "elsewhere"
+        other_dir.mkdir()
+        filepath = other_dir / "page.md"
+        filepath.write_text("# Outside CWD")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = dump_page(filepath, output_dir)
+
+        assert result is not None
+        assert result.name == "page.adf.json"
+
+
+class TestDumpTree:
+    """Tests for dump_tree — local ADF generation for a directory."""
+
+    def test_dump_tree_processes_all_files(self, tmp_path, monkeypatch):
+        """dump_tree processes all .md files in the directory."""
+        monkeypatch.chdir(tmp_path)
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "a.md").write_text("# A")
+        (docs / "b.md").write_text("# B")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        results = dump_tree(docs, docs, output_dir)
+
+        assert len(results) == 2
+        assert all(r is not None for r in results)
+
+    def test_dump_tree_excludes_page_content_md(self, tmp_path, monkeypatch):
+        """dump_tree skips .page_content.md files."""
+        monkeypatch.chdir(tmp_path)
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "page.md").write_text("# Page")
+        (docs / ".page_content.md").write_text("# Container")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        results = dump_tree(docs, docs, output_dir)
+
+        assert len(results) == 1
+
+    def test_dump_tree_handles_errors_gracefully(self, tmp_path, monkeypatch):
+        """dump_tree continues when individual files fail."""
+        monkeypatch.chdir(tmp_path)
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "good.md").write_text("# Good")
+        bad_file = docs / "bad.md"
+        bad_file.write_text("# Bad")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        # Make bad_file unreadable after discovery
+        from unittest.mock import patch
+
+        original_read = bad_file.read_text
+
+        def fail_on_bad(*args, **kwargs):
+            raise OSError("permission denied")
+
+        with patch.object(type(bad_file), "read_text", side_effect=[fail_on_bad, original_read]):
+            results = dump_tree(docs, docs, output_dir)
+
+        # Should have attempted both files (one error, one success)
+        assert len(results) == 2

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,10 +1,10 @@
-"""Tests for plan.planner — DeployPlan, PageAction, OrphanAction, compute_plan."""
+"""Tests for plan.planner — DeployPlan, PageAction, DestroyAction, compute_plan."""
 
 import os
 from pathlib import Path
 from unittest.mock import Mock
 
-from ccfm_convert.plan.planner import DeployPlan, OrphanAction, PageAction, compute_plan
+from ccfm_convert.plan.planner import DeployPlan, DestroyAction, PageAction, compute_plan
 from ccfm_convert.state.manager import StateManager
 
 # ---------------------------------------------------------------------------
@@ -31,31 +31,31 @@ def _write_md(directory: Path, name: str, content: str = "# Hello") -> Path:
 
 class TestDeployPlanHasChanges:
     def test_has_changes_false_when_all_no_op(self):
-        """has_changes is False when every action is NO_OP and no orphans (line 50)."""
+        """has_changes is False when every action is no-op and no destroys."""
         plan = DeployPlan(
             page_actions=[
                 PageAction(
                     filepath=Path("a.md"),
                     rel_path="a.md",
-                    action="NO_OP",
+                    action="no-op",
                     title="A",
                     current_hash="sha256:x",
                     stored_hash="sha256:x",
                     page_id="1",
                 )
             ],
-            orphan_actions=[],
+            destroy_actions=[],
         )
         assert plan.has_changes() is False
 
-    def test_has_changes_true_when_create_present(self):
-        """has_changes is True when any action is CREATE."""
+    def test_has_changes_true_when_add_present(self):
+        """has_changes is True when any action is add."""
         plan = DeployPlan(
             page_actions=[
                 PageAction(
                     filepath=Path("a.md"),
                     rel_path="a.md",
-                    action="CREATE",
+                    action="add",
                     title="A",
                     current_hash="sha256:x",
                 )
@@ -63,14 +63,14 @@ class TestDeployPlanHasChanges:
         )
         assert plan.has_changes() is True
 
-    def test_has_changes_true_when_update_present(self):
-        """has_changes is True when any action is UPDATE."""
+    def test_has_changes_true_when_change_present(self):
+        """has_changes is True when any action is change."""
         plan = DeployPlan(
             page_actions=[
                 PageAction(
                     filepath=Path("a.md"),
                     rel_path="a.md",
-                    action="UPDATE",
+                    action="change",
                     title="A",
                     current_hash="sha256:new",
                     stored_hash="sha256:old",
@@ -80,11 +80,11 @@ class TestDeployPlanHasChanges:
         )
         assert plan.has_changes() is True
 
-    def test_has_changes_true_when_orphan_present(self):
-        """has_changes is True when orphan_actions is non-empty (line 51)."""
+    def test_has_changes_true_when_destroy_present(self):
+        """has_changes is True when destroy_actions is non-empty."""
         plan = DeployPlan(
             page_actions=[],
-            orphan_actions=[OrphanAction(rel_path="docs/gone.md", page_id="99", title="Gone")],
+            destroy_actions=[DestroyAction(rel_path="docs/gone.md", page_id="99", title="Gone")],
         )
         assert plan.has_changes() is True
 
@@ -111,20 +111,32 @@ class TestDeployPlanPrintSummary:
             sys.stdout = old
         return buf.getvalue()
 
-    def test_print_summary_empty_plan(self):
-        """Empty plan prints 'No files found' message (lines 68-71)."""
+    def test_print_summary_no_files(self):
+        """Empty plan prints 'No files found' message."""
         plan = DeployPlan()
         output = self._capture(plan)
         assert "No files found" in output
 
-    def test_print_summary_create_action(self):
-        """CREATE actions show '+' symbol (lines 73-76)."""
+    def test_print_summary_no_changes(self):
+        """All no-op plan prints 'up to date' message."""
+        plan = DeployPlan(
+            page_actions=[
+                PageAction(Path("s.md"), "s.md", "no-op", "S", "sha256:s", "sha256:s", "1")
+            ]
+        )
+        output = self._capture(plan)
+        assert "up to date" in output
+        # no-op files should NOT be listed individually
+        assert "s.md" not in output
+
+    def test_print_summary_add_action(self):
+        """add actions show '+' symbol."""
         plan = DeployPlan(
             page_actions=[
                 PageAction(
                     filepath=Path("new.md"),
                     rel_path="docs/new.md",
-                    action="CREATE",
+                    action="add",
                     title="New Page",
                     current_hash="sha256:x",
                 )
@@ -132,17 +144,17 @@ class TestDeployPlanPrintSummary:
         )
         output = self._capture(plan)
         assert "+" in output
-        assert "CREATE" in output
+        assert "(add)" in output
         assert "New Page" in output
 
-    def test_print_summary_update_action(self):
-        """UPDATE actions show '~' symbol."""
+    def test_print_summary_change_action(self):
+        """change actions show '~' symbol."""
         plan = DeployPlan(
             page_actions=[
                 PageAction(
                     filepath=Path("upd.md"),
                     rel_path="docs/upd.md",
-                    action="UPDATE",
+                    action="change",
                     title="Updated",
                     current_hash="sha256:new",
                     stored_hash="sha256:old",
@@ -152,70 +164,39 @@ class TestDeployPlanPrintSummary:
         )
         output = self._capture(plan)
         assert "~" in output
-        assert "UPDATE" in output
+        assert "(change)" in output
 
-    def test_print_summary_no_op_action(self):
-        """NO_OP actions show '·' symbol."""
+    def test_print_summary_destroy_action(self):
+        """Destroy actions show '-' symbol and '(destroy)'."""
         plan = DeployPlan(
-            page_actions=[
-                PageAction(
-                    filepath=Path("same.md"),
-                    rel_path="docs/same.md",
-                    action="NO_OP",
-                    title="Unchanged",
-                    current_hash="sha256:x",
-                    stored_hash="sha256:x",
-                    page_id="1",
-                )
-            ]
+            destroy_actions=[DestroyAction(rel_path="docs/gone.md", page_id="7", title="Gone Page")]
         )
         output = self._capture(plan)
-        assert "·" in output
-        assert "NO-OP" in output
-
-    def test_print_summary_orphan_action(self):
-        """Orphan actions show '-' symbol and '(file removed)' (lines 78-81)."""
-        plan = DeployPlan(
-            orphan_actions=[OrphanAction(rel_path="docs/gone.md", page_id="7", title="Gone Page")]
-        )
-        output = self._capture(plan)
-        assert "ARCHIVE" in output
-        assert "file removed" in output
+        assert "-" in output
+        assert "(destroy)" in output
         assert "Gone Page" in output
 
     def test_print_summary_plan_line_with_all_action_types(self):
-        """Plan summary line lists creates, updates, archives, unchanged (lines 83-99)."""
+        """Plan summary line lists adds, changes, destroys, unchanged."""
         plan = DeployPlan(
             page_actions=[
-                PageAction(Path("c.md"), "c.md", "CREATE", "C", "sha256:c"),
-                PageAction(Path("u.md"), "u.md", "UPDATE", "U", "sha256:u", "sha256:old", "1"),
-                PageAction(Path("n.md"), "n.md", "NO_OP", "N", "sha256:n", "sha256:n", "2"),
+                PageAction(Path("c.md"), "c.md", "add", "C", "sha256:c"),
+                PageAction(Path("u.md"), "u.md", "change", "U", "sha256:u", "sha256:old", "1"),
+                PageAction(Path("n.md"), "n.md", "no-op", "N", "sha256:n", "sha256:n", "2"),
             ],
-            orphan_actions=[OrphanAction(rel_path="o.md", page_id="3", title="O")],
+            destroy_actions=[DestroyAction(rel_path="o.md", page_id="3", title="O")],
         )
         output = self._capture(plan)
-        assert "1 to create" in output
-        assert "1 to update" in output
-        assert "1 to archive" in output
+        assert "1 to add" in output
+        assert "1 to change" in output
+        assert "1 to destroy" in output
         assert "1 unchanged" in output
 
-    def test_print_summary_shows_run_without_plan_when_changes(self):
-        """'Run without --plan to apply.' appears when has_changes() is True (lines 101-103)."""
-        plan = DeployPlan(
-            page_actions=[PageAction(Path("x.md"), "x.md", "CREATE", "X", "sha256:x")]
-        )
+    def test_print_summary_shows_actions_header_when_changes(self):
+        """'ccfm will perform the following actions' appears when has_changes() is True."""
+        plan = DeployPlan(page_actions=[PageAction(Path("x.md"), "x.md", "add", "X", "sha256:x")])
         output = self._capture(plan)
-        assert "Run without --plan to apply." in output
-
-    def test_print_summary_no_run_prompt_when_all_no_op(self):
-        """'Run without --plan' is suppressed when has_changes() is False."""
-        plan = DeployPlan(
-            page_actions=[
-                PageAction(Path("s.md"), "s.md", "NO_OP", "S", "sha256:s", "sha256:s", "1")
-            ]
-        )
-        output = self._capture(plan)
-        assert "Run without --plan" not in output
+        assert "ccfm will perform the following actions" in output
 
 
 # ---------------------------------------------------------------------------
@@ -225,10 +206,7 @@ class TestDeployPlanPrintSummary:
 
 class TestDeriveTitleViaComputePlan:
     def test_title_from_frontmatter(self, tmp_path):
-        """_derive_title returns the frontmatter title when present (lines 112-113).
-
-        The frontmatter parser reads titles from page_meta.title, not a top-level title key.
-        """
+        """_derive_title returns the frontmatter title when present."""
         docs = tmp_path / "docs"
         docs.mkdir()
         f = _write_md(docs, "guide.md", "---\npage_meta:\n  title: My Guide\n---\n# Content")
@@ -244,7 +222,7 @@ class TestDeriveTitleViaComputePlan:
         assert plan.page_actions[0].title == "My Guide"
 
     def test_title_derived_from_stem_when_no_frontmatter(self, tmp_path):
-        """_derive_title generates from stem when no frontmatter title (line 117)."""
+        """_derive_title generates from stem when no frontmatter title."""
         docs = tmp_path / "docs"
         docs.mkdir()
         f = _write_md(docs, "my-cool-page.md", "# No frontmatter here")
@@ -260,7 +238,7 @@ class TestDeriveTitleViaComputePlan:
         assert plan.page_actions[0].title == "My Cool Page"
 
     def test_title_falls_back_on_oserror(self, tmp_path):
-        """_derive_title catches OSError and falls back to stem (lines 115-116)."""
+        """_derive_title catches OSError and falls back to stem."""
         from unittest.mock import patch
 
         docs = tmp_path / "docs"
@@ -272,7 +250,6 @@ class TestDeriveTitleViaComputePlan:
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            # Patch Path.read_text on the specific instance to raise OSError
             with patch(
                 "ccfm_convert.plan.planner.Path.read_text", side_effect=OSError("disk error")
             ):
@@ -289,8 +266,8 @@ class TestDeriveTitleViaComputePlan:
 
 
 class TestComputePlan:
-    def test_create_when_no_state_entry(self, tmp_path):
-        """File with no state entry gets CREATE action (lines 150-159)."""
+    def test_add_when_no_state_entry(self, tmp_path):
+        """File with no state entry gets add action."""
         docs = tmp_path / "docs"
         docs.mkdir()
         f = _write_md(docs, "new.md")
@@ -304,11 +281,11 @@ class TestComputePlan:
             os.chdir(old_cwd)
 
         assert len(plan.page_actions) == 1
-        assert plan.page_actions[0].action == "CREATE"
+        assert plan.page_actions[0].action == "add"
         assert plan.page_actions[0].page_id is None
 
-    def test_update_when_hash_changed(self, tmp_path):
-        """File with mismatched hash gets UPDATE action (lines 160-171)."""
+    def test_change_when_hash_changed(self, tmp_path):
+        """File with mismatched hash gets change action."""
         docs = tmp_path / "docs"
         docs.mkdir()
         f = _write_md(docs, "changed.md", "# Version 1")
@@ -318,18 +295,17 @@ class TestComputePlan:
         os.chdir(tmp_path)
         try:
             rel = str(f.relative_to(tmp_path))
-            # Set stale hash
             state.set_page(rel, "p1", "Changed", "SP", "s", "sha256:stale")
             plan = compute_plan(state, [f], docs)
         finally:
             os.chdir(old_cwd)
 
-        assert plan.page_actions[0].action == "UPDATE"
+        assert plan.page_actions[0].action == "change"
         assert plan.page_actions[0].page_id == "p1"
         assert plan.page_actions[0].stored_hash == "sha256:stale"
 
     def test_no_op_when_hash_unchanged(self, tmp_path):
-        """File with matching hash gets NO_OP action (lines 172-183)."""
+        """File with matching hash gets no-op action."""
         docs = tmp_path / "docs"
         docs.mkdir()
         f = _write_md(docs, "same.md", "# Stable")
@@ -345,11 +321,11 @@ class TestComputePlan:
         finally:
             os.chdir(old_cwd)
 
-        assert plan.page_actions[0].action == "NO_OP"
+        assert plan.page_actions[0].action == "no-op"
         assert plan.page_actions[0].stored_hash == current_hash
 
-    def test_no_orphans_when_archive_orphans_false(self, tmp_path):
-        """Orphan detection is skipped when archive_orphans=False (line 185)."""
+    def test_destroys_detected_by_default(self, tmp_path):
+        """Files tracked in state but absent from disk are destroy actions (always on)."""
         docs = tmp_path / "docs"
         docs.mkdir()
         state = _make_state(tmp_path)
@@ -357,24 +333,39 @@ class TestComputePlan:
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            # rel_path will be "docs/deleted.md" (relative to cwd=tmp_path)
             deleted = docs / "deleted.md"
             rel = str(deleted.relative_to(tmp_path))
-            state.set_page(rel, "old", "Deleted", "SP", "s", "sha256:x")
+            state.set_page(rel, "old-page", "Deleted", "SP", "s", "sha256:x")
 
-            # docs_root must be Path("docs") so find_orphans' relative_to check works
-            plan = compute_plan(state, [], Path("docs"), archive_orphans=False)
+            plan = compute_plan(state, [], Path("docs"))
         finally:
             os.chdir(old_cwd)
 
-        assert plan.orphan_actions == []
+        assert len(plan.destroy_actions) == 1
+        assert plan.destroy_actions[0].page_id == "old-page"
+        assert plan.destroy_actions[0].action == "destroy"
 
-    def test_orphans_detected_when_archive_orphans_true(self, tmp_path):
-        """Orphan entries are added when archive_orphans=True (lines 185-195).
+    def test_force_classifies_existing_as_add(self, tmp_path):
+        """force=True makes all files show as add regardless of state."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f = _write_md(docs, "existing.md", "# Content")
+        state = _make_state(tmp_path)
 
-        docs_root must be the relative form matching the rel_path prefix for the
-        find_orphans relative_to check to pass.
-        """
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            rel = str(f.relative_to(tmp_path))
+            current_hash = state.compute_hash(f)
+            state.set_page(rel, "p1", "Existing", "SP", "s", current_hash)
+            plan = compute_plan(state, [f], docs, force=True)
+        finally:
+            os.chdir(old_cwd)
+
+        assert plan.page_actions[0].action == "add"
+
+    def test_directory_container_destroyed_when_no_children_remain(self, tmp_path):
+        """Directory container pages are destroyed when no .md files remain under them."""
         docs = tmp_path / "docs"
         docs.mkdir()
         state = _make_state(tmp_path)
@@ -382,20 +373,82 @@ class TestComputePlan:
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            deleted = docs / "deleted.md"
-            rel = str(deleted.relative_to(tmp_path))  # "docs/deleted.md"
-            state.set_page(rel, "old-page", "Deleted", "SP", "s", "sha256:x")
+            # Track a directory container and its child file in state
+            state.set_page("docs/team", "dir-1", "Team", "SP", "s", "")
+            state.set_page("docs/team/page.md", "p1", "Page", "SP", "s", "sha256:x")
 
-            plan = compute_plan(state, [], Path("docs"), archive_orphans=True)
+            # No files on disk — both should be destroyed
+            plan = compute_plan(state, [], Path("docs"))
         finally:
             os.chdir(old_cwd)
 
-        assert len(plan.orphan_actions) == 1
-        assert plan.orphan_actions[0].page_id == "old-page"
-        assert plan.orphan_actions[0].action == "ARCHIVE"
+        destroy_paths = [a.rel_path for a in plan.destroy_actions]
+        assert "docs/team/page.md" in destroy_paths
+        assert "docs/team" in destroy_paths
+
+    def test_directory_container_kept_when_children_exist(self, tmp_path):
+        """Directory container pages are NOT destroyed when children still exist on disk."""
+        docs = tmp_path / "docs"
+        (docs / "team").mkdir(parents=True)
+        f = _write_md(docs / "team", "page.md", "# Content")
+        state = _make_state(tmp_path)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            rel = str(f.relative_to(tmp_path))
+            current_hash = state.compute_hash(f)
+            state.set_page("docs/team", "dir-1", "Team", "SP", "s", "")
+            state.set_page(rel, "p1", "Page", "SP", "s", current_hash)
+
+            plan = compute_plan(state, [f], Path("docs"))
+        finally:
+            os.chdir(old_cwd)
+
+        assert len(plan.destroy_actions) == 0
+
+    def test_destroys_sorted_deepest_first(self, tmp_path):
+        """Destroy actions are sorted deepest-first (children before parents)."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        state = _make_state(tmp_path)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            state.set_page("docs/a", "d1", "A", "SP", "s", "")
+            state.set_page("docs/a/b", "d2", "B", "SP", "s", "")
+            state.set_page("docs/a/b/page.md", "p1", "Page", "SP", "s", "sha256:x")
+
+            plan = compute_plan(state, [], Path("docs"))
+        finally:
+            os.chdir(old_cwd)
+
+        destroy_paths = [a.rel_path for a in plan.destroy_actions]
+        assert destroy_paths.index("docs/a/b/page.md") < destroy_paths.index("docs/a/b")
+        assert destroy_paths.index("docs/a/b") < destroy_paths.index("docs/a")
+
+    def test_non_empty_hash_non_md_entry_ignored(self, tmp_path):
+        """State entries without .md suffix and with non-empty content_hash are ignored."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        state = _make_state(tmp_path)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Simulate a non-directory, non-.md entry with a real hash
+            state.set_page("docs/weird-entry", "p99", "Weird", "SP", "s", "sha256:notempty")
+
+            plan = compute_plan(state, [], Path("docs"))
+        finally:
+            os.chdir(old_cwd)
+
+        # Should not be destroyed (content_hash != "")
+        assert all(a.rel_path != "docs/weird-entry" for a in plan.destroy_actions)
 
     def test_files_sorted_in_output(self, tmp_path):
-        """Files are processed in sorted order (line 140)."""
+        """Files are processed in sorted order."""
         docs = tmp_path / "docs"
         docs.mkdir()
         fb = _write_md(docs, "b.md")
@@ -413,15 +466,12 @@ class TestComputePlan:
         assert rel_paths == sorted(rel_paths)
 
     def test_rel_path_falls_back_to_str_when_outside_cwd(self, tmp_path):
-        """ValueError from relative_to falls back to str(filepath) (lines 143-144)."""
+        """ValueError from relative_to falls back to str(filepath)."""
         docs = tmp_path / "docs"
         docs.mkdir()
         f = _write_md(docs, "page.md")
         state = _make_state(tmp_path)
 
-        # Create a sibling directory that is guaranteed NOT to be an ancestor of
-        # tmp_path on any platform.  Using tmp_path.parent / "unrelated_cwd" ensures
-        # it sits beside (not above) tmp_path, so relative_to() will always raise.
         unrelated_cwd = tmp_path.parent / "unrelated_cwd"
         unrelated_cwd.mkdir(exist_ok=True)
 
@@ -432,7 +482,6 @@ class TestComputePlan:
         finally:
             os.chdir(old_cwd)
 
-        # rel_path should be the full absolute string, not raise
         assert str(f) == plan.page_actions[0].rel_path
 
     def test_empty_files_list_produces_empty_plan(self, tmp_path):
@@ -449,4 +498,4 @@ class TestComputePlan:
             os.chdir(old_cwd)
 
         assert plan.page_actions == []
-        assert plan.orphan_actions == []
+        assert plan.destroy_actions == []


### PR DESCRIPTION
## Summary

- Add top-level `ccfm dump` subcommand (replaces `apply --dump`) for local markdown-to-ADF conversion without API calls
- Dump output defaults to `.ccfm/dumps/<timestamp>_<hash>/` instead of cluttering project root with `.ccfm-dump-*` dirs
- Refactor plan/apply into separate subcommands with shared planner module
- Add `dump_page()` and `dump_tree()` to orchestration layer
- Add file/directory existence validation with clear error messages
- Add interactive manual test script (`tests/smoke/manual_test.sh`) and MANUAL_TESTING.md runbook
- Add CLI help smoke tests
- 100% unit test coverage maintained (581 passed)

## Test plan

- [x] All 581 unit tests pass with 100% coverage
- [x] Manual smoke test script runs through all 8 phases
- [ ] CI pipeline passes
- [ ] Smoke tests pass against live Confluence

🤖 Generated with [Claude Code](https://claude.com/claude-code)