### PR TITLE
fix(config): raise error for non-dict YAML configs

### DIFF
--- a/src/ccfm_convert/config/loader.py
+++ b/src/ccfm_convert/config/loader.py
@@ -52,7 +52,7 @@ _VALID_TOP_LEVEL_KEYS = frozenset(_CONFIG_TO_ARG) | {"version", "deployments"}
 
 
 class ConfigValidationError(Exception):
-    """Raised when a ccfm.yaml file contains unrecognised keys."""
+    """Raised when a ccfm.yaml file fails structural or key validation."""
 
 
 def interpolate_env(value: str) -> str:
@@ -81,7 +81,12 @@ def _validate_config(config: dict, path: Path) -> None:
         ConfigValidationError: if unrecognised keys are found.
     """
     if not isinstance(config, dict):
-        return
+        actual_type = type(config).__name__
+        raise ConfigValidationError(
+            f"Config file {path} must contain key-value pairs at the top level, "
+            f"but found {actual_type}. "
+            f"See https://ccfm.io/configuration/ for the correct format."
+        )
 
     unknown = sorted(set(config) - _VALID_TOP_LEVEL_KEYS)
     if unknown:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -289,9 +289,16 @@ class TestConfigValidation:
         with pytest.raises(ConfigValidationError, match="'foo'"):
             load_config(cfg)
 
-    def test_scalar_yaml_skips_validation(self, tmp_path):
-        """A YAML file containing only a scalar value passes validation."""
+    def test_scalar_yaml_raises_validation_error(self, tmp_path):
+        """A YAML file containing only a scalar value raises ConfigValidationError."""
         cfg = tmp_path / "ccfm.yaml"
         cfg.write_text("just a string\n", encoding="utf-8")
-        result = load_config(cfg)
-        assert result == "just a string"
+        with pytest.raises(ConfigValidationError, match="must contain key-value pairs"):
+            load_config(cfg)
+
+    def test_list_yaml_raises_validation_error(self, tmp_path):
+        """A YAML file containing a list at the top level raises ConfigValidationError."""
+        cfg = tmp_path / "ccfm.yaml"
+        cfg.write_text("- item1\n- item2\n", encoding="utf-8")
+        with pytest.raises(ConfigValidationError, match="must contain key-value pairs"):
+            load_config(cfg)


### PR DESCRIPTION
## Summary

- `_validate_config` in `loader.py` silently returned when config was not a dict (scalar string, list), allowing malformed configs through
- Now raises `ConfigValidationError` with a descriptive message and link to docs
- Covers both scalar YAML (`just a string`) and list YAML (`- item1\n- item2`) cases

Closes #29

## Test plan

- [x] Updated `test_scalar_yaml_skips_validation` -> `test_scalar_yaml_raises_validation_error` to assert error is raised
- [x] Added `test_list_yaml_raises_validation_error` for list case
- [x] All 633 unit tests pass with 100% coverage