### PR TITLE
docs(cli): add env var fallback hints for --domain and --email

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,8 +31,8 @@ These apply to all commands:
 
 ```text
 --config PATH          Path to ccfm.yaml config file (default: ccfm.yaml if present)
---domain DOMAIN        Confluence domain (e.g., company.atlassian.net)
---email EMAIL          User email address
+--domain DOMAIN        Confluence domain (or set CONFLUENCE_DOMAIN env var)
+--email EMAIL          User email (or set CONFLUENCE_EMAIL env var)
 --token TOKEN          Atlassian API token (or set CONFLUENCE_TOKEN env var)
 --space SPACE          Space key (e.g., DOCS — not the space display name)
 ```


### PR DESCRIPTION
## Summary

- Update `docs/cli-reference.md` global options table to mention `CONFLUENCE_DOMAIN` and `CONFLUENCE_EMAIL` env var fallbacks, matching the v1.1.3 CLI behaviour and help text

## Test plan

- [x] `mkdocs build` produces no warnings
- [x] Help text in `--domain`/`--email` flags matches docs