### PR TITLE
docs: clarify single-repo-single-space rule

### DIFF
--- a/docs/deployment-patterns.md
+++ b/docs/deployment-patterns.md
@@ -123,6 +123,17 @@ directory.
 
 ---
 
+## Anti-Pattern: Multiple Repos, Same Space
+
+Do **not** deploy to the same Confluence space from multiple repositories. Each apply compares
+its `docs_root` against state — pages from another repository will appear as orphans and be
+destroyed.
+
+If you need multiple teams contributing to the same space, use a single repository with
+team-owned subdirectories (see Pattern 1 in the [FAQ](index.md#multiple-teams-need-to-publish-documentation--whats-the-best-approach)).
+
+---
+
 ## Examples Repository
 
 For complete working examples of these patterns with CI/CD configurations, see the

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,25 @@ examples.
     CCFM's orphan detection treats pages not in the current `docs_root` as deleted — a second
     repo deploying to the same space will destroy the first repo's pages.
 
+### Why one repo per space?
+
+CCFM's deployment model tracks state — which pages exist, their content hashes, and when they
+were last deployed. Orphan detection compares this state against the files in your `docs_root`
+to determine what should be created, updated, or destroyed. This only works when a single source
+of truth owns the state.
+
+This is the same constraint that Terraform and other state-based tools enforce: each state file
+should be managed by exactly one configuration. When two configurations share state, each one
+sees the other's resources as orphans and plans to destroy them.
+
+Unlike infrastructure tools where a bad destroy can be permanent, CCFM docs live in version
+control. If pages are accidentally destroyed, recovery is a re-deploy from the correct
+repository — no data is lost, just temporarily unavailable.
+
+The `plan` command always shows pending destroy actions before any changes are applied, and
+`apply` requires explicit confirmation (or `--auto-approve` for CI). These guardrails give
+you visibility before any destructive action is taken.
+
 ---
 
 ## Quick Start

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,6 +40,19 @@ Run `ccfm apply --force --auto-approve` to re-push all pages. The links will res
 second pass. Alternatively, use Confluence's **Children Display macro** in the editor instead
 of manual page links — it automatically lists child pages and won't be overwritten by CCFM.
 
+## Pages unexpectedly destroyed
+
+If pages disappear after an apply, the most likely cause is **two repositories deploying to the
+same Confluence space**. CCFM's orphan detection treats pages not in the current `docs_root` as
+deleted — so the second repository's apply will destroy pages created by the first.
+
+**Recovery:**
+
+1. Re-run `ccfm apply` from the **original** repository — the docs are still in version control
+2. Ensure each Confluence space is managed by exactly one `ccfm.yaml` configuration
+
+See [Design Philosophy — Why one repo per space?](index.md#why-one-repo-per-space) for details.
+
 ## Page hierarchy issues
 
 Ensure markdown files are under your `docs_root` directory. Directories without


### PR DESCRIPTION
## Summary

- Add "Why one repo per space?" section to design philosophy explaining the state management constraint and the Terraform parallel
- Add troubleshooting entry for accidental multi-repo deployment with recovery steps
- Add anti-pattern section to deployment patterns

Closes #49 — after design review, decided to document the constraint rather than implement an ownership token. See the [issue discussion](https://github.com/stevesimpson418/ccfm-convert/issues/49#issuecomment-4128599319) for full rationale.

## Test plan

- [ ] Verify docs render correctly on ccfm.io
- [ ] Confirm anchor link `#why-one-repo-per-space` resolves in the design philosophy section
- [ ] Confirm troubleshooting cross-reference link works