### PR TITLE
feat(config): add global ci_banner toggle to ccfm.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to CCFM are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [2.2.0] - 2026-04-28
+
+### Added
+
+- Global `ci_banner` toggle in `ccfm.yaml` — set `ci_banner: false` to disable the
+  CI banner project-wide without editing each file's frontmatter. Adds matching
+  `--ci-banner` / `--no-ci-banner` CLI flags. Per-page frontmatter still takes
+  precedence ([#66](https://github.com/stevesimpson418/ccfm-convert/issues/66))
+
 ## [2.1.1] - 2026-03-27
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,23 @@ token: ${CONFLUENCE_TOKEN}
 space: DOCS
 docs_root: docs
 git_repo_url: https://github.com/org/repo
+ci_banner: true                  # Show CI banner on all pages (default: true)
+ci_banner_text: "Custom banner"  # Optional — overrides default banner text
 ```
+
+### ci_banner (optional)
+
+Set `ci_banner: false` in `ccfm.yaml` to disable the CI banner across every page in the
+project without needing to add `ci_banner: false` to each file's frontmatter. Per-page
+frontmatter still wins — a file with `deploy_config.ci_banner: true` will keep its banner
+even when the global toggle is off.
+
+Precedence (highest first):
+
+1. Per-page frontmatter `deploy_config.ci_banner`
+2. CLI flags `--ci-banner` / `--no-ci-banner`
+3. Global `ci_banner` in `ccfm.yaml`
+4. Default (`true`)
 
 ### docs_root (required)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ccfm-convert"
-version = "2.1.1"
+version = "2.2.0"
 description = "Deploy Markdown as native ADF pages to Confluence Cloud"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/ccfm_convert/config/loader.py
+++ b/src/ccfm_convert/config/loader.py
@@ -12,6 +12,7 @@ Supported schema:
     space: DOCS
     docs_root: docs
     git_repo_url: https://github.com/org/repo
+    ci_banner: false                                      # Disable banners project-wide
     ci_banner_text: "⚠️ Custom banner text applied to all pages"
 
     # Optional multi-space routing
@@ -46,6 +47,7 @@ _CONFIG_TO_ARG = {
     "space": "space",
     "docs_root": "docs_root",
     "git_repo_url": "git_repo_url",
+    "ci_banner": "ci_banner",
     "ci_banner_text": "ci_banner_text",
 }
 

--- a/src/ccfm_convert/deploy/frontmatter.py
+++ b/src/ccfm_convert/deploy/frontmatter.py
@@ -59,7 +59,9 @@ def parse_frontmatter(content):
         "labels": page_meta.get("labels", []),
         "attachments": page_meta.get("attachments", []),
         # Deploy config with defaults
-        "ci_banner": deploy_config.get("ci_banner", True),
+        # ci_banner has no default here so add_ci_banner can distinguish
+        # "absent" (apply global/default) from explicit True/False.
+        "ci_banner": deploy_config.get("ci_banner"),
         "ci_banner_text": deploy_config.get("ci_banner_text"),
         "include_page_metadata": deploy_config.get("include_page_metadata", False),
         "page_status": deploy_config.get("page_status", "current"),

--- a/src/ccfm_convert/deploy/orchestration.py
+++ b/src/ccfm_convert/deploy/orchestration.py
@@ -15,6 +15,7 @@ def ensure_page_hierarchy(
     docs_root,
     git_repo_url="",
     ci_banner_text=None,
+    ci_banner=None,
     changed_containers=None,
 ):
     """
@@ -31,6 +32,8 @@ def ensure_page_hierarchy(
         docs_root: Root documentation directory (e.g., Path("docs"))
         git_repo_url: Git repo URL for CI banner
         ci_banner_text: Optional global CI banner text from ccfm.yaml
+        ci_banner: Optional global ci_banner toggle from ccfm.yaml.
+            Per-page frontmatter ci_banner takes precedence.
         changed_containers: Optional set of directory relative paths (relative to
             docs_root) whose .page_content.md actually changed. When provided,
             only directories in this set will have their pages updated.
@@ -89,7 +92,13 @@ def ensure_page_hierarchy(
 
             # Add CI banner if enabled
             file_git_url = f"{git_repo_url}/{page_content_file}" if git_repo_url else ""
-            body = add_ci_banner(body, metadata, file_git_url, global_ci_banner_text=ci_banner_text)
+            body = add_ci_banner(
+                body,
+                metadata,
+                file_git_url,
+                global_ci_banner_text=ci_banner_text,
+                global_ci_banner=ci_banner,
+            )
 
             labels = metadata.get("labels", [])
             author = metadata.get("author")
@@ -160,6 +169,7 @@ def deploy_tree(
     git_repo_url="",
     files=None,
     ci_banner_text=None,
+    ci_banner=None,
     changed_containers=None,
 ):
     """
@@ -175,6 +185,8 @@ def deploy_tree(
             via rglob. Used by apply to limit deployment to actionable files.
         ci_banner_text: Optional global CI banner text from ccfm.yaml.
             Per-page frontmatter ci_banner_text takes precedence.
+        ci_banner: Optional global ci_banner toggle from ccfm.yaml.
+            Per-page frontmatter ci_banner takes precedence.
         changed_containers: Optional set of directory relative paths (relative to
             docs_root) whose .page_content.md actually changed. Forwarded to
             ensure_page_hierarchy to skip unnecessary updates.
@@ -208,6 +220,7 @@ def deploy_tree(
                 docs_root,
                 git_repo_url,
                 ci_banner_text=ci_banner_text,
+                ci_banner=ci_banner,
                 changed_containers=changed_containers,
             )
             for hp in h_pages:
@@ -216,7 +229,13 @@ def deploy_tree(
                     seen_dirs.add(hp[0])
 
             page_id = deploy_page(
-                api, space_id, parent_id, filepath, git_repo_url, ci_banner_text=ci_banner_text
+                api,
+                space_id,
+                parent_id,
+                filepath,
+                git_repo_url,
+                ci_banner_text=ci_banner_text,
+                ci_banner=ci_banner,
             )
             results.append((filepath, page_id))
         except Exception as e:
@@ -276,7 +295,15 @@ def destroy_pages(api, state, destroy_actions) -> int:
     return destroyed
 
 
-def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", ci_banner_text=None):
+def deploy_page(
+    api,
+    space_id,
+    parent_id,
+    filepath,
+    git_repo_url="",
+    ci_banner_text=None,
+    ci_banner=None,
+):
     """
     Deploy a single markdown file to Confluence.
 
@@ -295,6 +322,8 @@ def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", ci_banner_t
         git_repo_url: Git repository URL for CI banner
         ci_banner_text: Optional global CI banner text from ccfm.yaml.
             Per-page frontmatter ci_banner_text takes precedence.
+        ci_banner: Optional global ci_banner toggle from ccfm.yaml.
+            Per-page frontmatter ci_banner takes precedence.
     """
     print(f"\n📄 Processing: {filepath.name}")
 
@@ -315,7 +344,13 @@ def deploy_page(api, space_id, parent_id, filepath, git_repo_url="", ci_banner_t
     body = convert(markdown)
 
     # Add CI banner unless explicitly disabled
-    body = add_ci_banner(body, metadata, file_git_url, global_ci_banner_text=ci_banner_text)
+    body = add_ci_banner(
+        body,
+        metadata,
+        file_git_url,
+        global_ci_banner_text=ci_banner_text,
+        global_ci_banner=ci_banner,
+    )
 
     # Resolve internal Confluence page links
     body = resolve_page_links(body, api, space_id)

--- a/src/ccfm_convert/deploy/transforms.py
+++ b/src/ccfm_convert/deploy/transforms.py
@@ -7,12 +7,22 @@ from ccfm_convert.adf.inline import parse_inline_with_breaks
 from ccfm_convert.adf.nodes import expand, paragraph, resolve_image_width
 
 
-def add_ci_banner(adf_doc, metadata, file_git_url="", global_ci_banner_text=None):
+def add_ci_banner(
+    adf_doc,
+    metadata,
+    file_git_url="",
+    global_ci_banner_text=None,
+    global_ci_banner=None,
+):
     """
     Conditionally prepend CI banner to ADF document based on metadata.
 
-    Checks metadata["ci_banner"] (defaults to True when absent) and,
-    if enabled, builds and prepends a CI banner panel.
+    Resolves whether the banner is shown via the following precedence
+    (highest first):
+
+      1. Per-page frontmatter ``ci_banner``
+      2. Global ``ci_banner`` from ``ccfm.yaml``
+      3. Default (``True``)
 
     Args:
         adf_doc: The ADF document dict
@@ -20,8 +30,19 @@ def add_ci_banner(adf_doc, metadata, file_git_url="", global_ci_banner_text=None
         file_git_url: Optional git file URL for source link
         global_ci_banner_text: Optional global banner text from ccfm.yaml.
             Per-page frontmatter ci_banner_text takes precedence.
+        global_ci_banner: Optional global ci_banner toggle from ccfm.yaml.
+            Per-page frontmatter ci_banner takes precedence. ``None`` means
+            "not configured" — falls back to the default ``True``.
     """
-    if metadata.get("ci_banner", True):
+    fm_ci_banner = metadata.get("ci_banner")
+    if fm_ci_banner is not None:
+        enabled = bool(fm_ci_banner)
+    elif global_ci_banner is not None:
+        enabled = bool(global_ci_banner)
+    else:
+        enabled = True
+
+    if enabled:
         fm_text = metadata.get("ci_banner_text")
         banner_text = fm_text if fm_text is not None else global_ci_banner_text
         adf_doc = _build_ci_banner(

--- a/src/ccfm_convert/main.py
+++ b/src/ccfm_convert/main.py
@@ -80,8 +80,18 @@ def _add_global_args(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_target_args(parser: argparse.ArgumentParser) -> None:
-    """Add --git-repo-url shared by plan and apply."""
+    """Add target args shared by plan and apply."""
     parser.add_argument("--git-repo-url", default="", help="Git repo URL for CI banner")
+    parser.add_argument(
+        "--ci-banner",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Enable/disable the CI banner globally. Use --no-ci-banner to disable "
+            "across all pages. Overridden by per-page ci_banner in frontmatter. "
+            "Defaults to True when neither CLI nor ccfm.yaml sets it."
+        ),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -282,7 +292,14 @@ def _handle_plan(args, parser):
         git_repo_url = getattr(args, "git_repo_url", "")
         file_url = f"{git_repo_url}/{debug_file}" if git_repo_url else ""
         global_ci_banner_text = getattr(args, "ci_banner_text", None)
-        body = add_ci_banner(body, metadata, file_url, global_ci_banner_text=global_ci_banner_text)
+        global_ci_banner = getattr(args, "ci_banner", None)
+        body = add_ci_banner(
+            body,
+            metadata,
+            file_url,
+            global_ci_banner_text=global_ci_banner_text,
+            global_ci_banner=global_ci_banner,
+        )
         print(json.dumps(body, indent=2))
         return
 
@@ -380,6 +397,7 @@ def _handle_apply(args, parser):
 
     git_repo_url = getattr(args, "git_repo_url", "")
     ci_banner_text = getattr(args, "ci_banner_text", None)
+    ci_banner = getattr(args, "ci_banner", None)
     try:
         # Separate regular files from .page_content.md files
         regular_actionable = [
@@ -418,6 +436,7 @@ def _handle_apply(args, parser):
                 git_repo_url,
                 files=actionable_files,
                 ci_banner_text=ci_banner_text,
+                ci_banner=ci_banner,
                 changed_containers=changed_containers,
             )
             all_hierarchy_pages.extend(hierarchy_pages)
@@ -445,6 +464,7 @@ def _handle_apply(args, parser):
                         args.docs_root,
                         git_repo_url,
                         ci_banner_text=ci_banner_text,
+                        ci_banner=ci_banner,
                         changed_containers=changed_containers,
                     )
                     for hp in h_pages:

--- a/tests/smoke/test_global_ci_banner.py
+++ b/tests/smoke/test_global_ci_banner.py
@@ -1,0 +1,124 @@
+"""Smoke tests: global ci_banner toggle from ccfm.yaml config."""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from tests.smoke.conftest import PROJECT_ROOT
+
+pytestmark = pytest.mark.smoke
+
+
+class TestGlobalCIBanner:
+    """Verify ci_banner toggle in ccfm.yaml flows through to ADF output."""
+
+    def test_global_ci_banner_false_disables_banner(self, tmp_path):
+        """plan --debug-file omits the banner when ccfm.yaml sets ci_banner: false."""
+        config = tmp_path / "ccfm.yaml"
+        config.write_text("ci_banner: false\n")
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Simple page\n\nSome content.")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "ccfm_convert",
+                "--config",
+                str(config),
+                "plan",
+                "--debug-file",
+                str(test_file),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"debug-file failed:\n{result.stderr}"
+        data = json.loads(result.stdout)
+        # No banner panel should be prepended.
+        assert data["content"][0]["type"] != "panel"
+
+    def test_frontmatter_overrides_global_ci_banner_false(self, tmp_path):
+        """Per-page ci_banner: true overrides global ci_banner: false."""
+        config = tmp_path / "ccfm.yaml"
+        config.write_text("ci_banner: false\n")
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("---\ndeploy_config:\n  ci_banner: true\n---\n# Test")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "ccfm_convert",
+                "--config",
+                str(config),
+                "plan",
+                "--debug-file",
+                str(test_file),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"debug-file failed:\n{result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["content"][0]["type"] == "panel"
+
+    def test_no_ci_banner_cli_flag_disables_banner(self, tmp_path):
+        """--no-ci-banner CLI flag disables the banner."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Simple page\n\nSome content.")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "ccfm_convert",
+                "plan",
+                "--no-ci-banner",
+                "--debug-file",
+                str(test_file),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"debug-file failed:\n{result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["content"][0]["type"] != "panel"
+
+    def test_default_banner_when_no_global_or_frontmatter(self, tmp_path):
+        """Banner is shown by default when neither config nor frontmatter set ci_banner."""
+        config = tmp_path / "ccfm.yaml"
+        config.write_text("version: 1\n")
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Simple page\n\nSome content.")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "ccfm_convert",
+                "--config",
+                str(config),
+                "plan",
+                "--debug-file",
+                str(test_file),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"debug-file failed:\n{result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["content"][0]["type"] == "panel"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -171,6 +171,7 @@ class TestMergeConfigWithArgs:
             "space": "SP",
             "docs_root": "docs",
             "git_repo_url": "https://github.com/org/repo",
+            "ci_banner": False,
             "ci_banner_text": "Global banner",
         }
         args = Namespace(
@@ -180,6 +181,7 @@ class TestMergeConfigWithArgs:
             space=None,
             docs_root=None,
             git_repo_url=None,
+            ci_banner=None,
             ci_banner_text=None,
         )
         merged = merge_config_with_args(config, args)
@@ -189,6 +191,7 @@ class TestMergeConfigWithArgs:
         assert merged.space == "SP"
         assert merged.docs_root == Path("docs")
         assert merged.git_repo_url == "https://github.com/org/repo"
+        assert merged.ci_banner is False
         assert merged.ci_banner_text == "Global banner"
 
     def test_ci_banner_text_from_config_fills_args(self):
@@ -197,6 +200,24 @@ class TestMergeConfigWithArgs:
         args = Namespace(domain=None, email=None, token=None, space=None, docs_root=None)
         merged = merge_config_with_args(config, args)
         assert merged.ci_banner_text == "Global banner text"
+
+    def test_ci_banner_from_config_fills_args(self):
+        """ci_banner=False from config is applied when not set on args."""
+        config = {"ci_banner": False}
+        args = Namespace(
+            domain=None, email=None, token=None, space=None, docs_root=None, ci_banner=None
+        )
+        merged = merge_config_with_args(config, args)
+        assert merged.ci_banner is False
+
+    def test_ci_banner_cli_overrides_config(self):
+        """An explicit CLI ci_banner value takes precedence over the config value."""
+        config = {"ci_banner": False}
+        args = Namespace(
+            domain=None, email=None, token=None, space=None, docs_root=None, ci_banner=True
+        )
+        merged = merge_config_with_args(config, args)
+        assert merged.ci_banner is True
 
     def test_docs_root_from_config_sets_path(self):
         """docs_root from config is coerced to Path."""
@@ -222,11 +243,13 @@ class TestConfigValidation:
         cfg.write_text(
             "version: 1\ndomain: x.atlassian.net\nemail: a@b.com\n"
             "token: tok\nspace: SP\ndocs_root: docs\ngit_repo_url: https://gh.com/o/r\n"
+            "ci_banner: false\n"
             "ci_banner_text: Custom global banner\n",
             encoding="utf-8",
         )
         result = load_config(cfg)
         assert result["domain"] == "x.atlassian.net"
+        assert result["ci_banner"] is False
         assert result["ci_banner_text"] == "Custom global banner"
 
     def test_deployments_key_accepted(self, tmp_path):

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -23,7 +23,9 @@ class TestFrontmatterParsing:
 
         # Empty frontmatter returns defaults
         assert metadata["title"] is None
-        assert metadata["ci_banner"] is True  # Default
+        # ci_banner is None when absent so add_ci_banner can apply the
+        # global ccfm.yaml ci_banner toggle before falling back to True.
+        assert metadata["ci_banner"] is None
         assert metadata["deploy_page"] is True  # Default
         assert markdown == "# Content"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1005,6 +1005,78 @@ class TestDebugFile:
         banner_text = data["content"][0]["content"][0]["content"][0]["text"]
         assert banner_text == "Page override"
 
+    def test_debug_file_global_ci_banner_false_disables_banner(self, tmp_path, capsys):
+        """--debug-file honours ci_banner: false from ccfm.yaml."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        config_file = tmp_path / "ccfm.yaml"
+        config_file.write_text("ci_banner: false\n")
+
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "--config",
+                str(config_file),
+                "plan",
+                "--debug-file",
+                str(test_file),
+            ],
+        ):
+            main.main()
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        # No banner panel should be present.
+        assert data["content"][0]["type"] != "panel"
+
+    def test_debug_file_no_ci_banner_cli_flag_disables_banner(self, tmp_path, capsys):
+        """--no-ci-banner CLI flag disables the banner."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Test")
+
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "plan",
+                "--no-ci-banner",
+                "--debug-file",
+                str(test_file),
+            ],
+        ):
+            main.main()
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["content"][0]["type"] != "panel"
+
+    def test_debug_file_frontmatter_overrides_global_ci_banner_false(self, tmp_path, capsys):
+        """Per-page ci_banner=true overrides global ci_banner=false."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("---\ndeploy_config:\n  ci_banner: true\n---\n# Test")
+
+        config_file = tmp_path / "ccfm.yaml"
+        config_file.write_text("ci_banner: false\n")
+
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "--config",
+                str(config_file),
+                "plan",
+                "--debug-file",
+                str(test_file),
+            ],
+        ):
+            main.main()
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["content"][0]["type"] == "panel"
+
 
 # ---------------------------------------------------------------------------
 # Apply subcommand — directory deployment
@@ -1112,6 +1184,62 @@ class TestApplyDocsRoot:
         mock_deploy_tree.assert_called_once()
         call_kwargs = mock_deploy_tree.call_args
         assert call_kwargs[1]["ci_banner_text"] == "Global banner"
+
+    @patch("ccfm_convert.main.LockManager")
+    @patch("ccfm_convert.main.StateManager")
+    @patch("ccfm_convert.main.ConfluenceBackend")
+    @patch("ccfm_convert.main.deploy_tree")
+    @patch("ccfm_convert.main.compute_plan")
+    @patch("ccfm_convert.main._find_management_page", return_value="mgmt-page-id")
+    @patch("ccfm_convert.main.ConfluenceAPI")
+    def test_apply_passes_ci_banner_toggle_to_deploy_tree(
+        self,
+        mock_api_class,
+        mock_find_mgmt,
+        mock_compute_plan,
+        mock_deploy_tree,
+        mock_backend_class,
+        mock_state_class,
+        mock_lock_class,
+        tmp_path,
+    ):
+        """Apply passes ci_banner from config to deploy_tree."""
+        test_dir = tmp_path / "docs"
+        test_dir.mkdir()
+        f1 = test_dir / "page.md"
+        f1.write_text("# Page")
+
+        config_path = tmp_path / "ccfm.yaml"
+        config_path.write_text(
+            f"version: 1\n"
+            f"domain: example.atlassian.net\n"
+            f"email: test@example.com\n"
+            f"token: token\n"
+            f"space: TEST\n"
+            f"docs_root: {test_dir}\n"
+            f"ci_banner: false\n"
+        )
+
+        mock_api = Mock()
+        mock_api.get_space_id.return_value = "space123"
+        mock_api_class.return_value = mock_api
+        mock_deploy_tree.return_value = ([], [])
+
+        mock_compute_plan.return_value = _mock_plan_with_changes([f1])
+
+        mock_state = Mock()
+        mock_state_class.return_value = mock_state
+        mock_lock = Mock()
+        mock_lock_class.return_value = mock_lock
+
+        with patch(
+            "sys.argv",
+            ["main.py", "--config", str(config_path), "apply", "--auto-approve"],
+        ):
+            main.main()
+
+        mock_deploy_tree.assert_called_once()
+        assert mock_deploy_tree.call_args[1]["ci_banner"] is False
 
     @patch("ccfm_convert.main.LockManager")
     @patch("ccfm_convert.main.StateManager")

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -145,6 +145,27 @@ class TestEnsurePageHierarchy:
         banner_text = body["content"][0]["content"][0]["content"][0]["text"]
         assert banner_text == "Global banner"
 
+    def test_page_content_with_global_ci_banner_false(self, mock_api, tmp_path):
+        """ensure_page_hierarchy honours global ci_banner=False on .page_content.md pages."""
+        docs_root = tmp_path / "docs"
+        subdir = docs_root / "Team"
+        subdir.mkdir(parents=True)
+
+        page_content = subdir / ".page_content.md"
+        page_content.write_text("---\npage_meta:\n  title: Team Page\n---\nContent")
+
+        filepath = subdir / "child.md"
+
+        mock_api.find_page_by_title.return_value = None
+        mock_api.create_page.return_value = "parent-123"
+
+        ensure_page_hierarchy(mock_api, "space123", filepath, docs_root, ci_banner=False)
+
+        call_args = mock_api.create_page.call_args
+        body = call_args[0][3]
+        # No banner panel should be prepended.
+        assert body["content"][0]["type"] != "panel"
+
 
 class TestDeployPage:
     """Test page deployment."""
@@ -362,6 +383,35 @@ ci_banner: false
         body = call_args[0][3]
         banner_text = body["content"][0]["content"][0]["content"][0]["text"]
         assert banner_text == "Page-specific"
+
+    def test_deploy_page_global_ci_banner_false_disables_banner(self, mock_api, tmp_path):
+        """deploy_page applies global ci_banner=False to suppress the banner."""
+        filepath = tmp_path / "test.md"
+        filepath.write_text("# Test")
+
+        mock_api.find_page_by_title.return_value = None
+        mock_api.create_page.return_value = "new-123"
+
+        deploy_page(mock_api, "space123", None, filepath, ci_banner=False)
+
+        call_args = mock_api.create_page.call_args
+        body = call_args[0][3]
+        # First node should be the heading paragraph, not a banner panel
+        assert body["content"][0]["type"] != "panel"
+
+    def test_deploy_page_frontmatter_ci_banner_overrides_global_false(self, mock_api, tmp_path):
+        """Per-page ci_banner=true overrides a global ci_banner=false."""
+        filepath = tmp_path / "test.md"
+        filepath.write_text("---\ndeploy_config:\n  ci_banner: true\n---\n# Test")
+
+        mock_api.find_page_by_title.return_value = None
+        mock_api.create_page.return_value = "new-123"
+
+        deploy_page(mock_api, "space123", None, filepath, ci_banner=False)
+
+        call_args = mock_api.create_page.call_args
+        body = call_args[0][3]
+        assert body["content"][0]["type"] == "panel"
 
     def test_frontmatter_parent_ignored_uses_directory_hierarchy(self, mock_api, tmp_path):
         """deploy_page ignores deprecated parent frontmatter and uses directory hierarchy."""
@@ -798,6 +848,23 @@ class TestDeployTree:
         body = call_args[0][3]
         banner_text = body["content"][0]["content"][0]["content"][0]["text"]
         assert banner_text == "Global banner"
+
+    def test_deploy_tree_passes_ci_banner_toggle(self, mock_api, tmp_path):
+        """deploy_tree forwards ci_banner=False to suppress banner across pages."""
+        docs_root = tmp_path / "docs"
+        docs_root.mkdir()
+
+        file1 = docs_root / "test.md"
+        file1.write_text("# Test")
+
+        mock_api.find_page_by_title.return_value = None
+        mock_api.create_page.return_value = "page-123"
+
+        deploy_tree(mock_api, "space123", docs_root, ci_banner=False)
+
+        call_args = mock_api.create_page.call_args
+        body = call_args[0][3]
+        assert body["content"][0]["type"] != "panel"
 
     def test_deploy_with_hierarchy(self, mock_api, tmp_path):
         """Test deploying with directory hierarchy."""

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -201,6 +201,42 @@ class TestAddCIBanner:
         banner_text = result["content"][0]["content"][0]["content"][0]["text"]
         assert banner_text == ""
 
+    def test_global_ci_banner_false_disables_banner(self):
+        """Global ci_banner=False from ccfm.yaml disables banner when frontmatter is silent."""
+        adf_doc = doc([paragraph([text_node("Content")])])
+        result = add_ci_banner(adf_doc, {}, global_ci_banner=False)
+        assert result["content"][0]["type"] == "paragraph"
+
+    def test_global_ci_banner_true_enables_banner(self):
+        """Global ci_banner=True from ccfm.yaml enables banner when frontmatter is silent."""
+        adf_doc = doc([paragraph([text_node("Content")])])
+        result = add_ci_banner(adf_doc, {}, global_ci_banner=True)
+        assert result["content"][0]["type"] == "panel"
+
+    def test_frontmatter_ci_banner_true_overrides_global_false(self):
+        """Per-page ci_banner=True wins over global ci_banner=False."""
+        adf_doc = doc([paragraph([text_node("Content")])])
+        result = add_ci_banner(adf_doc, {"ci_banner": True}, global_ci_banner=False)
+        assert result["content"][0]["type"] == "panel"
+
+    def test_frontmatter_ci_banner_false_overrides_global_true(self):
+        """Per-page ci_banner=False wins over global ci_banner=True."""
+        adf_doc = doc([paragraph([text_node("Content")])])
+        result = add_ci_banner(adf_doc, {"ci_banner": False}, global_ci_banner=True)
+        assert result["content"][0]["type"] == "paragraph"
+
+    def test_none_metadata_ci_banner_falls_back_to_global(self):
+        """ci_banner=None in metadata (absent) falls through to the global toggle."""
+        adf_doc = doc([paragraph([text_node("Content")])])
+        result = add_ci_banner(adf_doc, {"ci_banner": None}, global_ci_banner=False)
+        assert result["content"][0]["type"] == "paragraph"
+
+    def test_default_true_when_neither_set(self):
+        """When neither frontmatter nor global is set, banner is shown."""
+        adf_doc = doc([paragraph([text_node("Content")])])
+        result = add_ci_banner(adf_doc, {})
+        assert result["content"][0]["type"] == "panel"
+
 
 class TestCreateMetadataExpand:
     """Test metadata expand creation."""


### PR DESCRIPTION
## Summary

Closes #66.

- Adds `ci_banner: true/false` as a top-level key in `ccfm.yaml` so the CI banner can be disabled project-wide without setting it on every file
- Adds matching `--ci-banner` / `--no-ci-banner` CLI flags
- Threads the new toggle through `deploy_tree`, `deploy_page`, and `ensure_page_hierarchy` so all deploy paths (regular pages, container pages, debug-file) respect it
- Per-page frontmatter `ci_banner` still wins, preserving existing behaviour

## Precedence (highest first)

1. Per-page frontmatter `deploy_config.ci_banner`
2. CLI flag (`--ci-banner` / `--no-ci-banner`)
3. Global `ci_banner` in `ccfm.yaml`
4. Default (`true`)

`parse_frontmatter` now returns `None` for absent `ci_banner` (previously `True`) so the precedence layer can distinguish "not set" from "explicitly true" before applying the global toggle. Only `add_ci_banner` consumes this value, and the existing default-`True` semantics are preserved at that layer.

## Test plan

- [x] Unit tests added in `test_transforms.py` covering all 6 precedence combinations
- [x] Integration tests in `test_main.py` covering `--debug-file` with config / CLI flags / frontmatter overrides
- [x] Apply-path test in `test_main.py` confirming `deploy_tree` receives the `ci_banner` kwarg
- [x] Orchestration tests in `test_orchestration.py` for `deploy_page`, `deploy_tree`, and `ensure_page_hierarchy`
- [x] Config loader tests in `test_config_loader.py` covering CLI-overrides-config and config-fills-args
- [x] New smoke test `tests/smoke/test_global_ci_banner.py` mirroring `test_global_ci_banner_text.py`
- [x] All 750 unit tests pass with 100% coverage
- [x] Ruff lint passes
- [x] Docs updated (`docs/configuration.md`)
- [x] CHANGELOG entry added; version bumped to 2.2.0