### PR TITLE
fix(config): honour git_repo_url from ccfm.yaml

### DIFF
--- a/src/ccfm_convert/main.py
+++ b/src/ccfm_convert/main.py
@@ -81,7 +81,7 @@ def _add_global_args(parser: argparse.ArgumentParser) -> None:
 
 def _add_target_args(parser: argparse.ArgumentParser) -> None:
     """Add target args shared by plan and apply."""
-    parser.add_argument("--git-repo-url", default="", help="Git repo URL for CI banner")
+    parser.add_argument("--git-repo-url", default=None, help="Git repo URL for CI banner")
     parser.add_argument(
         "--ci-banner",
         action=argparse.BooleanOptionalAction,
@@ -289,7 +289,7 @@ def _handle_plan(args, parser):
         content = debug_file.read_text(encoding="utf-8")
         metadata, markdown = parse_frontmatter(content)
         body = convert(markdown)
-        git_repo_url = getattr(args, "git_repo_url", "")
+        git_repo_url = getattr(args, "git_repo_url", None) or ""
         file_url = f"{git_repo_url}/{debug_file}" if git_repo_url else ""
         global_ci_banner_text = getattr(args, "ci_banner_text", None)
         global_ci_banner = getattr(args, "ci_banner", None)
@@ -395,7 +395,7 @@ def _handle_apply(args, parser):
         print(f"Error: {e}")
         sys.exit(1)
 
-    git_repo_url = getattr(args, "git_repo_url", "")
+    git_repo_url = getattr(args, "git_repo_url", None) or ""
     ci_banner_text = getattr(args, "ci_banner_text", None)
     ci_banner = getattr(args, "ci_banner", None)
     try:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -194,6 +194,34 @@ class TestMergeConfigWithArgs:
         assert merged.ci_banner is False
         assert merged.ci_banner_text == "Global banner"
 
+    def test_git_repo_url_from_config_fills_args(self):
+        """git_repo_url from config is applied when CLI arg is None.
+
+        Regression: --git-repo-url must default to None (not "") in argparse,
+        otherwise merge_config_with_args treats it as already-set and silently
+        drops the config value.
+        """
+        config = {"git_repo_url": "https://github.com/org/repo"}
+        args = Namespace(
+            domain=None, email=None, token=None, space=None, docs_root=None, git_repo_url=None
+        )
+        merged = merge_config_with_args(config, args)
+        assert merged.git_repo_url == "https://github.com/org/repo"
+
+    def test_git_repo_url_cli_overrides_config(self):
+        """An explicit CLI git_repo_url takes precedence over the config value."""
+        config = {"git_repo_url": "https://github.com/org/repo"}
+        args = Namespace(
+            domain=None,
+            email=None,
+            token=None,
+            space=None,
+            docs_root=None,
+            git_repo_url="https://gitlab.com/other/repo",
+        )
+        merged = merge_config_with_args(config, args)
+        assert merged.git_repo_url == "https://gitlab.com/other/repo"
+
     def test_ci_banner_text_from_config_fills_args(self):
         """ci_banner_text from config is applied when not set on args."""
         config = {"ci_banner_text": "Global banner text"}


### PR DESCRIPTION
## Summary

- `--git-repo-url` defaulted to `""` in argparse, so `merge_config_with_args` treated it as already-set and silently dropped the value from `ccfm.yaml`.
- Default the CLI flag to `None` instead, so config-file values are applied when the flag is omitted. The two read sites coerce `None` back to `""` for the downstream URL builder.
- Adds regression tests covering both `git_repo_url`-from-config and CLI-overrides-config behaviour.

## Test plan

- [x] `pytest tests/test_config_loader.py` — new and existing merge tests pass
- [x] Full suite: 752 passed, 15 skipped
- [x] `ruff check` clean
- [ ] Verify on a real deploy that the source link now renders in the CI banner when only `ccfm.yaml` sets `git_repo_url`