### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to CCFM are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.3.0] - 2026-05-13
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ccfm-convert"
-version = "2.2.2"
+version = "2.3.0"
 description = "Deploy Markdown as native ADF pages to Confluence Cloud"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Mechanical version bump to release the per-page content-property state backend ([#73](https://github.com/stevesimpson418/ccfm-convert/pull/73)).

- `pyproject.toml`: \`2.2.2\` → \`2.3.0\`
- `CHANGELOG.md`: \`## [Unreleased]\` → \`## [2.3.0] - 2026-05-13\`

## Versioning rationale

**Minor bump** because removing \`ConfluenceBackend\` and \`ConfluenceAPI.download_attachment\` is technically a breaking change for any code that imported those symbols programmatically (none known publicly), and existing installations need a one-shot migration step (download + \`ccfm state push\`). The CLI surface is unchanged.

## Validation status

End-to-end validated on two real Atlassian tenants before this bump:
- **CCFMDEV** (separate tenant, fresh install) — full lifecycle: init → apply → state pull/push round-trip → state rm → lock cycle. All green.
- **AIOPS / silverrail** (the tenant that motivated the fix) — \`state pull\` returns the expected empty shape (proving the 401 is gone), 29-entry migration via \`state push\` succeeded, \`ccfm plan\` correctly identifies real local drift on top of the migrated state.

## Release flow after merge

1. Merge this PR.
2. From local main:
   \`\`\`bash
   git checkout main && git pull
   git tag v2.3.0
   git push origin v2.3.0
   \`\`\`
3. The \`v*\` tag push triggers \`.github/workflows/release.yml\` → builds + publishes to PyPI.
4. AIOPS picks up \`2.3.0\` on next \`uv sync\` (the temporary git+ install used for validation gets overridden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)